### PR TITLE
refactor: Resource trending card layout sm

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -47,7 +47,6 @@
         "commonjs": true
       }
     ],
-    "simple-import-sort/imports": "error",
     "simple-import-sort/imports": [
       "error",
       {

--- a/frontend/src/components/dashboard/RankingOccuranceCharts/index.jsx
+++ b/frontend/src/components/dashboard/RankingOccuranceCharts/index.jsx
@@ -28,7 +28,7 @@ const RankingOccuranceCharts = (props) => {
     };
 
     return (
-      <Grid key={s.symbol} item lg={4} sm={4} xs={12}>
+      <Grid key={s.symbol} item lg={6} sm={12} xs={12}>
         <ABDonutChart data={chart_data} subheader="Occurance in the TOP list" />
       </Grid>
     );

--- a/frontend/src/components/dashboard/RankingScores/index.jsx
+++ b/frontend/src/components/dashboard/RankingScores/index.jsx
@@ -114,7 +114,7 @@ const RankingScores = (props) => {
   return (
     <Box mt={1}>
       <Grid container spacing={1}>
-        <Grid item lg={6} sm={7} xs={12}>
+        <Grid item lg={6} sm={6} xs={12}>
           <MyCard>
             <CardHeader
               title={<Typography variant="h3">Overall Scores</Typography>}
@@ -140,7 +140,7 @@ const RankingScores = (props) => {
             </CardContent>
           </MyCard>
         </Grid>
-        <Grid item lg={6} sm={5} xs={12}>
+        <Grid item lg={6} sm={6} xs={12}>
           <MyCard>
             <CardHeader
               title={


### PR DESCRIPTION
- Use `sm={6}` for resource trending card layout