### PR TITLE
feat: Deploy backend django using helm

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,18 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+node_modules
+k8s
+deployment
+.env*
+.flake8
+.isort.cfg
+.pre-commit.config.yaml
+static

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --upgrade pip
 
 # For some strange reason, this is required before
 # we hit `pip install -r`
-RUN pip install requests
+RUN pip install requests gunicorn
 
 # Set up code destination
 RUN mkdir /code
@@ -25,3 +25,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Collect static files
 RUN python manage.py collectstatic --noinput
+
+EXPOSE 80
+
+CMD ["gunicorn", "--bind", ":80", "fin.wsgi"]

--- a/backend/k8s/deploy.yml
+++ b/backend/k8s/deploy.yml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stock-backend-secret
+type: Opaque
+stringData:
+  MYSQL_USER: fengxia
+  MYSQL_PASSWORD: natalie
+  MYSQL_ROOT_PASSWORD: natalie
+  DJANGO_DB_USER: fengxia
+  DJANGO_DB_PWD: natalie
+
+---
+# frontend nginx conf
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stock-backend-env
+data:
+  MYSQL_DATABASE: stock
+  DEPLOY_TYPE: dev
+  DJANGO_DB_HOST: 192.168.68.106
+  DJANGO_REDIS_HOST: 192.168.68.106
+
+---
+# frontend react app
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stock-backend
+spec:
+  selector:
+    matchLabels:
+      app: stock-backend
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3
+  template:
+    metadata:
+      labels:
+        app: stock-backend
+    spec:
+      containers:
+        - name: stock-backend
+          image: harbor.feng.local:9800/library/backend_stock:v1.1.0.beta
+          ports:
+            - containerPort: 80
+          envFrom:
+          - configMapRef:
+              name: stock-backend-env
+          - secretRef:
+              name: stock-backend-secret
+      imagePullSecrets:
+        - name: harbor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-backend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: stock-backend
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stock-backend
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: mystock.backend.feng.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stock-backend
+                port:
+                  number: 80

--- a/backend/k8s/helm/.helmignore
+++ b/backend/k8s/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/backend/k8s/helm/Chart.yaml
+++ b/backend/k8s/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: stock-frontend
-description: Frontend for mystock app
+name: stock-backend
+description: Backend for mystock app
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/backend/k8s/helm/templates/NOTES.txt
+++ b/backend/k8s/helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "helm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/backend/k8s/helm/templates/_helpers.tpl
+++ b/backend/k8s/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm.labels" -}}
+helm.sh/chart: {{ include "helm.chart" . }}
+{{ include "helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/backend/k8s/helm/templates/deployment.yaml
+++ b/backend/k8s/helm/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm.fullname" . }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3
+
+  selector:
+    matchLabels:
+      {{- include "helm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helm.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+
+          envFrom:
+          - configMapRef:
+              name: "{{ .Release.Name }}-env"
+          - secretRef:
+              name: "{{ .Release.Name }}-secret"
+
+          livenessProbe:
+            httpGet:
+              path: /api/v1
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/v1
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/backend/k8s/helm/templates/env-configmap.yaml
+++ b/backend/k8s/helm/templates/env-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "helm.fullname" . }}-env
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.configMaps | nindent 2 }}

--- a/backend/k8s/helm/templates/env-secret.yaml
+++ b/backend/k8s/helm/templates/env-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "helm.fullname" . }}-secret
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.secrets | nindent 2 }}

--- a/backend/k8s/helm/templates/hpa.yaml
+++ b/backend/k8s/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "helm.fullname" . }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "helm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/backend/k8s/helm/templates/ingress.yaml
+++ b/backend/k8s/helm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helm.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/backend/k8s/helm/templates/service.yaml
+++ b/backend/k8s/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm.fullname" . }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "helm.selectorLabels" . | nindent 4 }}

--- a/backend/k8s/helm/templates/serviceaccount.yaml
+++ b/backend/k8s/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helm.serviceAccountName" . }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/backend/k8s/helm/templates/tests/test-connection.yaml
+++ b/backend/k8s/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "helm.fullname" . }}-test-connection"
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "helm.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/backend/k8s/helm/values.yaml
+++ b/backend/k8s/helm/values.yaml
@@ -1,0 +1,101 @@
+# Default values for helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: harbor.feng.local:9800/library/backend_stock
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v1.1.0.beta"
+
+imagePullSecrets:
+  - name: harbor
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: mystock.backend.feng.local
+      paths:
+        - path: /
+          pathType: Prefix
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 1024m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 1024m
+  #   memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+secrets:
+  MYSQL_USER: fengxia
+  MYSQL_PASSWORD: natalie
+  MYSQL_ROOT_PASSWORD: natalie
+  DJANGO_DB_USER: fengxia
+  DJANGO_DB_PWD: natalie
+
+configMaps:
+  MYSQL_DATABASE: stock
+  DEPLOY_TYPE: dev
+  DJANGO_DEBUG: "1"
+  DJANGO_DB_HOST: 192.168.68.106
+  DJANGO_DB_PORT: "3306"
+  DJANGO_REDIS_HOST: 192.168.68.106

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -1,6 +1,6 @@
 upstream django {
   # must be your docker host IP, `localhost` won't work!
-  server web:8001;
+  server web:80;
 }
 
 server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ volumes:
 x-django-base: &django-base
   build:
     context: ./backend
-    dockerfile: ./Dockerfile-web
+    dockerfile: ./Dockerfile
   image: backend_stock
   volumes:
     - ./backend:/code
@@ -29,7 +29,7 @@ x-django-base: &django-base
     DEPLOY_TYPE: dev # dev or prod
     DJANGO_DB_USER: fengxia
     DJANGO_DB_PWD: natalie
-    DJANGO_DB_HOST: db
+    DJANGO_DB_HOST: 192.168.68.106
     DJANGO_DB_PORT: 3306
     DJANGO_REDIS_HOST: redis
     # DJANGO_SUPERUSER_USERNAME: fengxia
@@ -55,6 +55,8 @@ services:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     restart: always
+    ports:
+      - "3306:3306"
     volumes:
       - stock-data:/var/lib/mysql # persisted volume
       - ./backend/mysql.cnf:/etc/mysql/conf.d/feng.cnf
@@ -71,7 +73,6 @@ services:
     <<: *django-base
 
     #command: bash -c "python /code/manage.py migrate --noinput && python /code/manage.py createsuperuser --noinput && python /code/manage.py runserver 0.0.0.0:8001"
-    command: bash -c "python /code/manage.py migrate --noinput && python /code/manage.py runserver 0.0.0.0:8001"
     # command:
     #   "python /code/manage.py createsuperuser --noinput && gunicorn -w 1 -t 300 -b 0.0.0.0:8001 --log-level=info fin.wsgi"
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,26 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+node_modules
+k8s
+deployment
+.env*
+.husky
+.huskyrc.json
+jsconfig.json
+.npmrc
+.prettierignore
+.prettierrc.json
+.yalc
+yalc.lock
+yarn.lock
+package.lock
+.yarnrc
+.yarnrc.yml

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_HOST_URL=http://192.168.68.106:8083
+REACT_APP_HOST_URL=http://mystock.backend.feng.local

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,4 +1,4 @@
-//npm.pkg.github.com/:_authToken=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
+//npm.pkg.github.com/:_authToken=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
 registry=https://registry.yarnpkg.com/
 @fengxia41103:registry=https://npm.pkg.github.com
 always-auth=true

--- a/frontend/k8s/deploy.yml
+++ b/frontend/k8s/deploy.yml
@@ -82,6 +82,7 @@ spec:
   selector:
     app: stock-frontend
 
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,9 +76,9 @@
   "name": "frontend2",
   "private": true,
   "scripts": {
-    "build": "DISABLE_ESLINT_PLUGIN=true craco --max_old_space_size=4096 build",
+    "build": "DISABLE_ESLINT_PLUGIN=true craco --max_old_space_size=2048 build",
     "eject": "craco eject",
-    "start": "craco --max_old_space_size=4096 start",
+    "start": "craco --max_old_space_size=2048 start",
     "test": "craco test"
   },
   "version": "0.1.0"


### PR DESCRIPTION
- Add backend deploy YAML and helm chart
- Change backend container port to 80
- Use guicorn to run django app inside the container
- Reduce frontend memory footprint
- Add dockerignore for backend and frontend