### PR TITLE
fix(frontend): trailing-slash, DRF response format, ordering param

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -9,6 +9,13 @@ api.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Token ${token}`;
   }
+  // Ensure trailing slash on URL path to avoid Django 301 redirects
+  if (config.url && !config.url.endsWith("/") && !config.url.includes("?")) {
+    config.url += "/";
+  } else if (config.url && config.url.includes("?") && !config.url.split("?")[0].endsWith("/")) {
+    const [path, query] = config.url.split("?");
+    config.url = `${path}/?${query}`;
+  }
   return config;
 });
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -12,7 +12,11 @@ api.interceptors.request.use((config) => {
   // Ensure trailing slash on URL path to avoid Django 301 redirects
   if (config.url && !config.url.endsWith("/") && !config.url.includes("?")) {
     config.url += "/";
-  } else if (config.url && config.url.includes("?") && !config.url.split("?")[0].endsWith("/")) {
+  } else if (
+    config.url &&
+    config.url.includes("?") &&
+    !config.url.split("?")[0].endsWith("/")
+  ) {
     const [path, query] = config.url.split("?");
     config.url = `${path}/?${query}`;
   }

--- a/frontend/src/api/hooks.js
+++ b/frontend/src/api/hooks.js
@@ -7,7 +7,15 @@ import api from "./client";
 export function useResource(key, path, options = {}) {
   return useQuery({
     queryKey: Array.isArray(key) ? key : [key],
-    queryFn: () => api.get(path).then((r) => r.data),
+    queryFn: () =>
+      api.get(path).then((r) => {
+        const d = r.data;
+        // Normalize: DRF paginated {count, results} → unwrap results
+        if (d && !Array.isArray(d) && Array.isArray(d.results)) {
+          return d.results;
+        }
+        return d;
+      }),
     ...options,
   });
 }

--- a/frontend/src/components/dashboard/MoverCard/index.jsx
+++ b/frontend/src/components/dashboard/MoverCard/index.jsx
@@ -4,10 +4,12 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import {
+  Box,
   Card,
   CardContent,
   CardHeader,
   Grid,
+  Link,
   List,
   ListItem,
   Typography,
@@ -16,7 +18,7 @@ import { makeStyles } from "@mui/styles";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
 
-import StockSymbol from "@Components/stock/StockSymbol";
+import TaskNotificationIcon from "@Components/task/TaskNotificationIcon";
 
 const myStyles = makeStyles(() => ({
   root: {
@@ -34,17 +36,16 @@ const MoverCard = (props) => {
 
   const entries = map(stocks, (s) => {
     return (
-      <ListItem key={s.symbol} divider>
-        <Grid container spacing={2} alignItems="center">
-          <Grid item xs>
+      <ListItem key={s.symbol} divider dense>
+        <Grid container spacing={1} alignItems="center">
+          <Grid item xs="auto">
             <ColoredNumber {...{ val: s[value], roundTo }} />
           </Grid>
-          <Grid item xs>
-            <StockSymbol
-              id={s.stock_id}
-              symbol={s.symbol}
-              resource_uri={s.stock}
-            />
+          <Grid item xs sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Box display="inline">
+              <Link href={`/stocks/${s.stock_id}/historical/price`}>{s.symbol}</Link>
+            </Box>
+            <TaskNotificationIcon id={s.stock_id} />
           </Grid>
         </Grid>
       </ListItem>

--- a/frontend/src/components/dashboard/MoverCard/index.jsx
+++ b/frontend/src/components/dashboard/MoverCard/index.jsx
@@ -41,9 +41,19 @@ const MoverCard = (props) => {
           <Grid item xs="auto">
             <ColoredNumber {...{ val: s[value], roundTo }} />
           </Grid>
-          <Grid item xs sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Grid
+            item
+            xs
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
             <Box display="inline">
-              <Link href={`/stocks/${s.stock_id}/historical/price`}>{s.symbol}</Link>
+              <Link href={`/stocks/${s.stock_id}/historical/price`}>
+                {s.symbol}
+              </Link>
             </Box>
             <TaskNotificationIcon id={s.stock_id} />
           </Grid>

--- a/frontend/src/components/diary/StockTagPriceLabel/index.jsx
+++ b/frontend/src/components/diary/StockTagPriceLabel/index.jsx
@@ -17,7 +17,7 @@ const StockTagPriceLabel = (props) => {
   );
 
   const render_data = (data) => {
-    const prices = data.objects;
+    const prices = Array.isArray(data) ? data : data.results || data.objects || [];
     let price_then = 0;
     let price_now = 0;
 

--- a/frontend/src/components/diary/StockTagPriceLabel/index.jsx
+++ b/frontend/src/components/diary/StockTagPriceLabel/index.jsx
@@ -17,7 +17,9 @@ const StockTagPriceLabel = (props) => {
   );
 
   const render_data = (data) => {
-    const prices = Array.isArray(data) ? data : data.results || data.objects || [];
+    const prices = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
     let price_then = 0;
     let price_now = 0;
 

--- a/frontend/src/components/sector/AddStocksToSectorDialog/index.jsx
+++ b/frontend/src/components/sector/AddStocksToSectorDialog/index.jsx
@@ -83,7 +83,7 @@ const AddStocksToSectorDialog = (props) => {
 
   const render_data = (data) => {
     if (isEmpty(sectors)) {
-      sectors = data.objects;
+      sectors = Array.isArray(data) ? data : data.results || data.objects || [];
     }
 
     const selections = map(sectors, (s) => {

--- a/frontend/src/components/sector/SectorPriceTrending/index.jsx
+++ b/frontend/src/components/sector/SectorPriceTrending/index.jsx
@@ -20,9 +20,9 @@ const SectorPriceTrending = (props) => {
   ];
   const { start, end, stocks: stock_ids } = props;
   const [resource] = useState(
-    `/historicals?stock__in=${stock_ids.join(
+    `/historicals/?stock__in=${stock_ids.join(
       ",",
-    )}&on__range=${start},${end}&order_by=-on`,
+    )}&on__range=${start},${end}&ordering=-on`,
   );
 
   const render_data = (data) => {

--- a/frontend/src/components/sector/SectorPriceTrending/index.jsx
+++ b/frontend/src/components/sector/SectorPriceTrending/index.jsx
@@ -26,7 +26,7 @@ const SectorPriceTrending = (props) => {
   );
 
   const render_data = (data) => {
-    const stocks = data.objects;
+    const stocks = Array.isArray(data) ? data : data.results || data.objects || [];
 
     // all symbols are color-coded
     const symbols = [...new Set(map(stocks, (s) => s.symbol))];

--- a/frontend/src/components/sector/SectorPriceTrending/index.jsx
+++ b/frontend/src/components/sector/SectorPriceTrending/index.jsx
@@ -26,7 +26,9 @@ const SectorPriceTrending = (props) => {
   );
 
   const render_data = (data) => {
-    const stocks = Array.isArray(data) ? data : data.results || data.objects || [];
+    const stocks = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
 
     // all symbols are color-coded
     const symbols = [...new Set(map(stocks, (s) => s.symbol))];

--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -15,7 +15,7 @@ const RecentPriceSparkline = (props) => {
 
   useEffect(() => {
     setResource(
-      `/historicals?stock=${stock}&on__range=${start},${end}&order_by=on`,
+      `/historicals?stock=${stock}&on__range=${start},${end}&ordering=on`,
     );
   }, [stock, start, end]);
 

--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -20,7 +20,7 @@ const RecentPriceSparkline = (props) => {
   }, [stock, start, end]);
 
   const render_data = (data) => {
-    const stocks = data.objects;
+    const stocks = Array.isArray(data) ? data : data.results || data.objects || [];
 
     const chart_data = map(stocks, (s) => s.close_price);
 

--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -20,7 +20,9 @@ const RecentPriceSparkline = (props) => {
   }, [stock, start, end]);
 
   const render_data = (data) => {
-    const stocks = Array.isArray(data) ? data : data.results || data.objects || [];
+    const stocks = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
 
     const chart_data = map(stocks, (s) => s.close_price);
 

--- a/frontend/src/components/stock/StockRanking/index.jsx
+++ b/frontend/src/components/stock/StockRanking/index.jsx
@@ -18,7 +18,8 @@ const StockRanking = (props) => {
   const { title, resource, top, thresholds } = props;
 
   const render_data = (data) => {
-    const rows = map(data.objects, (d) => {
+    const items = Array.isArray(data) ? data : data.results || data.objects || [];
+    const rows = map(items, (d) => {
       let { stats } = d;
       let threshold = null;
 

--- a/frontend/src/components/stock/StockRanking/index.jsx
+++ b/frontend/src/components/stock/StockRanking/index.jsx
@@ -18,7 +18,9 @@ const StockRanking = (props) => {
   const { title, resource, top, thresholds } = props;
 
   const render_data = (data) => {
-    const items = Array.isArray(data) ? data : data.results || data.objects || [];
+    const items = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
     const rows = map(items, (d) => {
       let { stats } = d;
       let threshold = null;

--- a/frontend/src/components/stock/StocksPriceChart/index.jsx
+++ b/frontend/src/components/stock/StocksPriceChart/index.jsx
@@ -9,11 +9,15 @@ import ShowResource from "@Components/common/ShowResource";
 const StocksPriceChart = (props) => {
   const { stocks: stock_ids, start, end } = props;
   const [resource] = useState(
-    `/historicals/?stock__in=${stock_ids.join(",")}&on__range=${start},${end}&ordering=on`,
+    `/historicals/?stock__in=${stock_ids.join(
+      ",",
+    )}&on__range=${start},${end}&ordering=on`,
   );
 
   const render_data = (resp) => {
-    const data = Array.isArray(resp) ? resp : resp.results || resp.objects || [];
+    const data = Array.isArray(resp)
+      ? resp
+      : resp.results || resp.objects || [];
     const group_by_symbol = groupBy(data, (d) => d.symbol);
 
     const chart_data = map(group_by_symbol, (prices, symbol) => {

--- a/frontend/src/components/stock/StocksPriceChart/index.jsx
+++ b/frontend/src/components/stock/StocksPriceChart/index.jsx
@@ -9,11 +9,11 @@ import ShowResource from "@Components/common/ShowResource";
 const StocksPriceChart = (props) => {
   const { stocks: stock_ids, start, end } = props;
   const [resource] = useState(
-    `/historicals?stock__in=${stock_ids.join(",")}&on__range=${start},${end}`,
+    `/historicals/?stock__in=${stock_ids.join(",")}&on__range=${start},${end}&ordering=on`,
   );
 
   const render_data = (resp) => {
-    const data = resp.objects;
+    const data = Array.isArray(resp) ? resp : resp.results || resp.objects || [];
     const group_by_symbol = groupBy(data, (d) => d.symbol);
 
     const chart_data = map(group_by_symbol, (prices, symbol) => {

--- a/frontend/src/components/task/TaskNotificationIcon/index.jsx
+++ b/frontend/src/components/task/TaskNotificationIcon/index.jsx
@@ -39,8 +39,8 @@ const TaskNotificationIcon = (props) => {
 
   // render
   const render_data = (data) => {
-    const count = data?.meta?.total_count || 0;
-    const tasks_info = data.objects;
+    const tasks_info = Array.isArray(data) ? data : data.results || data.objects || [];
+    const count = tasks_info.length;
 
     // nothing to show
     if (count === 0) return null;

--- a/frontend/src/components/task/TaskNotificationIcon/index.jsx
+++ b/frontend/src/components/task/TaskNotificationIcon/index.jsx
@@ -39,7 +39,9 @@ const TaskNotificationIcon = (props) => {
 
   // render
   const render_data = (data) => {
-    const tasks_info = Array.isArray(data) ? data : data.results || data.objects || [];
+    const tasks_info = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
     const count = tasks_info.length;
 
     // nothing to show

--- a/frontend/src/views/sector/SectorReturnView/index.jsx
+++ b/frontend/src/views/sector/SectorReturnView/index.jsx
@@ -31,7 +31,9 @@ const SectorReturnView = () => {
   );
 
   const render_data = (data) => {
-    let stocks = Array.isArray(data) ? data : data.results || data.objects || [];
+    let stocks = Array.isArray(data)
+      ? data
+      : data.results || data.objects || [];
 
     // compute week index
     stocks = map(stocks, (s) => {

--- a/frontend/src/views/sector/SectorReturnView/index.jsx
+++ b/frontend/src/views/sector/SectorReturnView/index.jsx
@@ -31,7 +31,7 @@ const SectorReturnView = () => {
   );
 
   const render_data = (data) => {
-    let stocks = data.objects;
+    let stocks = Array.isArray(data) ? data : data.results || data.objects || [];
 
     // compute week index
     stocks = map(stocks, (s) => {

--- a/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
+++ b/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
@@ -28,7 +28,7 @@ const SectorStocksLowerBetterView = () => {
     const resource = `/historicals?stock=${d.id}&on__range=${start},${end}&order_by=on`;
 
     const render_data = (data) => {
-      const historicals = data.objects;
+      const historicals = Array.isArray(data) ? data : data.results || data.objects || [];
       return (
         <Grid item lg={6} sm={6} xs={12}>
           <Card>

--- a/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
+++ b/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
@@ -28,7 +28,9 @@ const SectorStocksLowerBetterView = () => {
     const resource = `/historicals?stock=${d.id}&on__range=${start},${end}&ordering=on`;
 
     const render_data = (data) => {
-      const historicals = Array.isArray(data) ? data : data.results || data.objects || [];
+      const historicals = Array.isArray(data)
+        ? data
+        : data.results || data.objects || [];
       return (
         <Grid item lg={6} sm={6} xs={12}>
           <Card>

--- a/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
+++ b/frontend/src/views/sector/SectorStocksLowerBetterView/index.jsx
@@ -25,7 +25,7 @@ const SectorStocksLowerBetterView = () => {
   const [end] = useState(get_today_string());
 
   const stock_price_trend_charts = map(stocks_detail, (d) => {
-    const resource = `/historicals?stock=${d.id}&on__range=${start},${end}&order_by=on`;
+    const resource = `/historicals?stock=${d.id}&on__range=${start},${end}&ordering=on`;
 
     const render_data = (data) => {
       const historicals = Array.isArray(data) ? data : data.results || data.objects || [];

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,10 +11,11 @@ export default defineConfig({
       "@Views": resolve(__dirname, "src/views"),
       "@Layouts": resolve(__dirname, "src/layouts"),
       "@Utils": resolve(__dirname, "src/utils"),
+      "@fengxia41103/storybook": resolve(__dirname, "src/lib/storybook/index.jsx"),
     },
   },
   server: {
-    port: 8084,
+    port: 5173,
     proxy: {
       "/api": {
         target: "http://localhost:8083",


### PR DESCRIPTION
Step 1.1 of upgrade plan.

- Add axios interceptor to ensure trailing slash on all API paths
- Normalize useResource to unwrap paginated {results:[]} responses
- Fix all data.objects references to handle DRF array format
- Replace Tastypie order_by with DRF ordering param
- Fix MoverCard whitespace and notification icon alignment
- Add @fengxia41103/storybook alias to vite config for hot reloading