### PR TITLE
refactor(frontend): replace moment.js with dayjs

### DIFF
--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -1,5 +1,5 @@
 import { map } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { Sparklines, SparklinesCurve } from "react-sparklines";
@@ -9,8 +9,8 @@ import ShowResource from "@Components/common/ShowResource";
 const RecentPriceSparkline = (props) => {
   const DATE_FORMAT = "YYYY-MM-DD";
   const [resource, setResource] = useState("");
-  const [start] = useState(moment().add(-10, "d").format(DATE_FORMAT));
-  const [end] = useState(moment().format(DATE_FORMAT));
+  const [start] = useState(dayjs().subtract(10, "day").format(DATE_FORMAT));
+  const [end] = useState(dayjs().format(DATE_FORMAT));
   const { stock } = props;
 
   useEffect(() => {

--- a/frontend/src/utils/helper.js
+++ b/frontend/src/utils/helper.js
@@ -1,5 +1,5 @@
 import { map } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
 
 export const randomId = (prefix = "FX") => {
   return prefix + (Math.random() * 1e32).toString(12);
@@ -57,13 +57,13 @@ export const get_highlights = (interests) => {
 const DATE_FORMAT = "YYYY-MM-DD";
 
 export const get_today_string = () => {
-  return moment().format(DATE_FORMAT);
+  return dayjs().format(DATE_FORMAT);
 };
 
 export const get_last_week_string = () => {
-  return moment().add(-1, "w").format(DATE_FORMAT);
+  return dayjs().subtract(1, "week").format(DATE_FORMAT);
 };
 
 export const get_last_month_string = () => {
-  return moment().add(-1, "M").format(DATE_FORMAT);
+  return dayjs().subtract(1, "month").format(DATE_FORMAT);
 };

--- a/frontend/src/views/dashboard/DashboardTrendingView/index.jsx
+++ b/frontend/src/views/dashboard/DashboardTrendingView/index.jsx
@@ -1,5 +1,5 @@
 import { map } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
 import React, { useEffect, useState } from "react";
 
 import {
@@ -40,7 +40,7 @@ const DashboardTrendingView = () => {
 
   // states
   const [resource, setResource] = useState("");
-  const [today, setToday] = useState(moment());
+  const [today, setToday] = useState(dayjs());
   const [useTimeLapseRanking, setUseTimeLapseRanking] = useState(false);
 
   // default back track one week from today
@@ -50,7 +50,7 @@ const DashboardTrendingView = () => {
 
   // Compute start/end from today and backWeek
   const end = today.format(DATE_FORMAT);
-  const start = moment(today)
+  const start = dayjs(today)
     .add(-1 * parseInt(backWeek, 10), "w")
     .format(DATE_FORMAT);
 
@@ -61,7 +61,7 @@ const DashboardTrendingView = () => {
 
   // event handlers
   const today_change = (event) => {
-    const now = moment(event.target.value, DATE_FORMAT);
+    const now = dayjs(event.target.value);
     setToday(now);
   };
 

--- a/frontend/src/views/dashboard/TodayDashboardView/index.jsx
+++ b/frontend/src/views/dashboard/TodayDashboardView/index.jsx
@@ -1,5 +1,5 @@
 import { filter, map, reverse, sortBy } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
 import React, { useMemo, useState } from "react";
 
 import {
@@ -17,25 +17,24 @@ import ShowResource from "@Components/common/ShowResource";
 import MoverCard from "@Components/dashboard/MoverCard";
 
 const getLastTradingDay = (m) => {
-  const cloned = moment(m);
-  const day = cloned.day();
-  if (day === 0) cloned.subtract(2, "days");
-  else if (day === 6) cloned.subtract(1, "days");
-  return cloned;
+  let d = dayjs(m);
+  if (d.day() === 0) d = d.subtract(2, "day");
+  else if (d.day() === 6) d = d.subtract(1, "day");
+  return d;
 };
 
 const TodayDashboardView = () => {
   const TOP = 10;
-  const [today, setToday] = useState(() => getLastTradingDay(moment()));
+  const [today, setToday] = useState(() => getLastTradingDay(dayjs()));
 
   const resource = useMemo(() => {
     const end = today.format("YYYY-MM-DD");
-    const start = moment(today).subtract(3, "days").format("YYYY-MM-DD");
+    const start = dayjs(today).subtract(3, "days").format("YYYY-MM-DD");
     return `/historicals/?on__range=${start},${end}&ordering=-on`;
   }, [today]);
 
   const today_change = (event) => {
-    const now = moment(event.target.value, "YYYY-MM-DD");
+    const now = dayjs(event.target.value);
     setToday(getLastTradingDay(now));
   };
 
@@ -52,7 +51,7 @@ const TodayDashboardView = () => {
       ...s,
     }));
 
-    const today_string = today.format("dddd, ll");
+    const today_string = today.format("dddd, MMM D, YYYY");
 
     const dashboards = [
       {

--- a/frontend/src/views/sector/SectorReturnView/index.jsx
+++ b/frontend/src/views/sector/SectorReturnView/index.jsx
@@ -1,5 +1,7 @@
 import { groupBy, map, reverse } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
+import weekOfYear from "dayjs/plugin/weekOfYear";
+dayjs.extend(weekOfYear);
 import React, { useContext, useState } from "react";
 
 import {
@@ -37,7 +39,7 @@ const SectorReturnView = () => {
 
     // compute week index
     stocks = map(stocks, (s) => {
-      return { ...s, week: moment(s.on).week() };
+      return { ...s, week: dayjs(s.on).week() };
     });
 
     // group data by week index

--- a/frontend/src/views/stock/PriceView/index.jsx
+++ b/frontend/src/views/stock/PriceView/index.jsx
@@ -1,6 +1,8 @@
 import clsx from "clsx";
 import { groupBy, map, reverse } from "lodash";
-import moment from "moment";
+import dayjs from "dayjs";
+import weekOfYear from "dayjs/plugin/weekOfYear";
+dayjs.extend(weekOfYear);
 import React, { useContext } from "react";
 
 import {
@@ -36,7 +38,7 @@ const PriceView = () => {
   const classes = myStyles();
 
   const stocks = map(data, (d) => {
-    return { ...d, week: moment(d.on).week() };
+    return { ...d, week: dayjs(d.on).week() };
   });
 
   // group data by week index


### PR DESCRIPTION
Step 1.2 of upgrade plan.

- Migrate all 6 files from moment to dayjs (immutable, 2kB)
- Fix getLastTradingDay to use immutable subtract
- Add weekOfYear plugin for .week() usage
- Replace moment localized format with explicit format
- Eliminates mutation bugs that caused infinite render loops