### PR TITLE
feat(backend): add DRF pagination for list endpoints

### DIFF
--- a/backend/fin/settings.py
+++ b/backend/fin/settings.py
@@ -104,7 +104,8 @@ REST_FRAMEWORK = {
         "django_filters.rest_framework.DjangoFilterBackend",
         "rest_framework.filters.OrderingFilter",
     ],
-    "DEFAULT_PAGINATION_CLASS": None,
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 200,
 }
 
 # Celery

--- a/backend/stock/api/views.py
+++ b/backend/stock/api/views.py
@@ -90,6 +90,7 @@ def logout_view(request):
 class SectorViewSet(viewsets.ModelViewSet):
     serializer_class = SectorSerializer
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def get_queryset(self):
         return MySector.objects.filter(user=self.request.user)
@@ -110,6 +111,7 @@ class SectorViewSet(viewsets.ModelViewSet):
 
 class StockViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def get_serializer_class(self):
         if self.action == "retrieve":
@@ -238,6 +240,7 @@ class NewsViewSet(viewsets.ReadOnlyModelViewSet):
 class TaskViewSet(viewsets.mixins.ListModelMixin, viewsets.mixins.DestroyModelMixin, viewsets.GenericViewSet):
     serializer_class = TaskSerializer
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def get_queryset(self):
         return MyTask.objects.filter(user=self.request.user)
@@ -249,6 +252,7 @@ class TaskViewSet(viewsets.mixins.ListModelMixin, viewsets.mixins.DestroyModelMi
 class RankingViewSet(viewsets.ViewSet):
     """Base ranking viewset with shared logic."""
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def _get_object_list_helper(self, objects, sort_by, high_to_low):
         start = date.today() - timedelta(days=180)

--- a/frontend/src/components/common/Get/index.jsx
+++ b/frontend/src/components/common/Get/index.jsx
@@ -16,7 +16,10 @@ const Get = ({ uri, on_success, on_error, silent }) => {
       .get(encodeURI(uri))
       .then((r) => {
         if (!cancelled) {
-          setData(r.data);
+          // Normalize paginated responses
+          const d = r.data;
+          const normalized = d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
+          setData(normalized);
           setLoading(false);
         }
       })


### PR DESCRIPTION
Step 1.3 — Fixes /historicals/ 504 timeout (62k records now bounded to 200/page).

- PageNumberPagination with PAGE_SIZE=200
- Disabled on sectors, stocks, tasks, rankings
- Frontend Get component unwraps paginated responses