### PR TITLE
feat(backend): add Django Redis cache layer for rankings

### DIFF
--- a/backend/fin/settings.py
+++ b/backend/fin/settings.py
@@ -115,6 +115,17 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_RESULT_BACKEND = "django-db"
 
+# Cache
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+
 # CORS
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = ["*"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,9 @@ celery>=5.4.0
 redis>=5.0.0
 django-celery-results>=2.5.0
 
+# Cache
+django-redis>=5.4.0
+
 # Data sources
 yahooquery>=2.3.7
 yfinance>=0.2.40

--- a/backend/stock/api/views.py
+++ b/backend/stock/api/views.py
@@ -4,6 +4,8 @@ from datetime import date, timedelta
 
 from django.contrib.auth import authenticate, logout
 from django.contrib.auth.models import User
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from rest_framework import status, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action, api_view, permission_classes
@@ -295,6 +297,7 @@ class RankingViewSet(viewsets.ViewSet):
 
 
 class StockRankViewSet(RankingViewSet):
+    @method_decorator(cache_page(300))
     def list(self, request):
         attrs = [
             (0, "roe", True),
@@ -312,6 +315,7 @@ class StockRankViewSet(RankingViewSet):
 
 
 class BalanceRankViewSet(RankingViewSet):
+    @method_decorator(cache_page(300))
     def list(self, request):
         attrs = [
             (0, "current_ratio", True), (1, "quick_ratio", True),
@@ -330,6 +334,7 @@ class BalanceRankViewSet(RankingViewSet):
 
 
 class CashRankViewSet(RankingViewSet):
+    @method_decorator(cache_page(300))
     def list(self, request):
         attrs = [
             (0, "dividend_payout_ratio", True), (1, "operating_cash_flow_growth", True),
@@ -340,6 +345,7 @@ class CashRankViewSet(RankingViewSet):
 
 
 class IncomeRankViewSet(RankingViewSet):
+    @method_decorator(cache_page(300))
     def list(self, request):
         attrs = [
             (0, "net_income_growth_rate", True), (1, "operating_income_growth_rate", True),
@@ -357,6 +363,7 @@ class IncomeRankViewSet(RankingViewSet):
 
 
 class ValuationRankViewSet(RankingViewSet):
+    @method_decorator(cache_page(300))
     def list(self, request):
         attrs = [(0, "pe", False), (1, "pb", False), (2, "ps", False)]
         return Response(self._filter_results(request, self._get_ranks(request, ValuationRatio.objects, attrs)))


### PR DESCRIPTION
Step 1.6 — Add caching.

- Add django-redis, configure on Redis DB 1 (separate from Celery broker)
- Cache all 5 ranking endpoints with 5-min TTL
- Verified: Cache-Control: max-age=300 in headers, keys stored in Redis