### PR TITLE
refactor(backend): consolidate statement workers into base class

### DIFF
--- a/backend/stock/workers/base.py
+++ b/backend/stock/workers/base.py
@@ -1,0 +1,74 @@
+import logging
+
+import pandas as pd
+from yahooquery import Ticker
+
+from stock.models import MyStock
+
+logger = logging.getLogger("stock")
+
+M = 10**6
+B = 10**9
+
+
+class StatementWorker:
+    """Base class for Yahoo Finance statement workers.
+
+    Subclasses define:
+        model: Django model class
+        mapping: dict of {model_field: YahooColumnName}
+        yahoo_method: str name of Ticker method to call
+        frequency: "q" or "a" (default "q")
+        normalize_large: bool — divide large numbers by B (default True)
+    """
+
+    model = None
+    mapping = {}
+    yahoo_method = None
+    frequency = "q"
+    normalize_large = True
+
+    def __init__(self, symbol):
+        self.stock = MyStock.objects.get(symbol=symbol)
+
+    def get(self):
+        s = Ticker(self.stock.symbol, timeout=15)
+        method = getattr(s, self.yahoo_method)
+
+        if self.frequency:
+            df = method(frequency=self.frequency)
+        else:
+            df = method
+
+        # Handle property vs method
+        if callable(df):
+            df = df()
+
+        if isinstance(df, str) or (hasattr(df, '__contains__') and ("unavailable" in df or "error" in df)):
+            logger.error(f"{self.stock.symbol}: {df}")
+            return
+
+        df = df.where(pd.notnull(df), 0)
+
+        for row in df.itertuples(index=False):
+            instance, _ = self.model.objects.get_or_create(
+                stock=self.stock, on=row.asOfDate.date()
+            )
+
+            for field, col in self.mapping.items():
+                try:
+                    tmp = float(getattr(row, col))
+                except (AttributeError, TypeError, ValueError):
+                    tmp = 0
+
+                if self.normalize_large and abs(tmp) > M:
+                    tmp = tmp / B
+
+                setattr(instance, field, tmp)
+
+            instance.save()
+            self.post_save(instance)
+
+    def post_save(self, instance):
+        """Hook for subclasses to run after each record is saved."""
+        pass

--- a/backend/stock/workers/get_balance_sheet.py
+++ b/backend/stock/workers/get_balance_sheet.py
@@ -1,117 +1,69 @@
-import logging
-
-import pandas as pd
-
 from stock.models import BalanceSheet
-from stock.models import MyStock
-from yahooquery import Ticker
-
-logger = logging.getLogger("stock")
-
-M = 10 ** 6
-B = 10 ** 9
+from stock.workers.base import StatementWorker
 
 
-class MyBalanceSheet:
-    def __init__(self, symbol):
-        self.stock = MyStock.objects.get(symbol=symbol)
-
-    def get(self):
-        s = Ticker(self.stock.symbol, timeout=15)
-
-        # all numbers convert to million
-        df = s.balance_sheet(frequency="q")
-        if "unavailable" in df or "error" in df:
-            logger.error("{}: {}".format(self.stock.symbol, df))
-            return
-
-        # DB doesn't like NaN
-        df = df.where(pd.notnull(df), 0)
-
-        # mapping between model field (left) and data json key (right)
-        mapping = {
-            "ap": "AccountsPayable",
-            "cash_and_cash_equivalent": "CashAndCashEquivalents",
-            "cash_cash_equivalents_and_short_term_investments": "CashCashEquivalentsAndShortTermInvestments",
-            "common_stock": "CommonStock",
-            "common_stock_equity": "CommonStockEquity",
-            "invested_capital": "InvestedCapital",
-            "long_term_debt_and_capital_lease_obligation": "LongTermDebtAndCapitalLeaseObligation",
-            "machinery_furniture_equipment": "MachineryFurnitureEquipment",
-            "net_ppe": "NetPPE",
-            "net_tangible_assets": "NetTangibleAssets",
-            "payables": "Payables",
-            "payables_and_accrued_expenses": "PayablesAndAccruedExpenses",
-            "retained_earnings": "RetainedEarnings",
-            "stockholders_equity": "StockholdersEquity",
-            "tangible_book_value": "TangibleBookValue",
-            "total_assets": "TotalAssets",
-            "total_capitalization": "TotalCapitalization",
-            "total_debt": "TotalDebt",
-            "total_non_current_assets": "TotalNonCurrentAssets",
-            "working_capital": "WorkingCapital",
-            "gross_ppe": "GrossPPE",
-            "current_assets": "CurrentAssets",
-            "current_liabilities": "CurrentLiabilities",
-            "receivables": "Receivables",
-            "other_short_term_investments": "OtherShortTermInvestments",
-            "long_term_debt": "LongTermDebt",
-            "other_current_liabilities": "OtherCurrentLiabilities",
-            "land_and_improvements": "LandAndImprovements",
-            "ar": "AccountsReceivable",
-            "other_current_assets": "OtherCurrentAssets",
-            "investments_and_advances": "InvestmentsAndAdvances",
-            "current_debt": "CurrentDebt",
-            "inventory": "Inventory",
-            "total_tax_payable": "TotalTaxPayable",
-            "available_for_sale_securities": "AvailableForSaleSecurities",
-            "other_receivables": "OtherReceivables",
-            "other_current_borrowings": "OtherCurrentBorrowings",
-            "investmentin_financial_assets": "InvestmentinFinancialAssets",
-            "cash_equivalents": "CashEquivalents",
-            "cash_financial": "CashFinancial",
-            "commercial_paper": "CommercialPaper",
-            "current_deferred_liabilities": "CurrentDeferredLiabilities",
-            "current_deferred_revenue": "CurrentDeferredRevenue",
-            "leases": "Leases",
-            "net_debt": "NetDebt",
-            "accumulated_depreciation": "AccumulatedDepreciation",
-            "allowance_for_doubtful_accounts_receivable": "AllowanceForDoubtfulAccountsReceivable",
-            "properties": "Properties",
-            "goodwill": "Goodwill",
-            "goodwill_and_other_intangible_assets": "GoodwillAndOtherIntangibleAssets",
-            "other_intangible_assets": "OtherIntangibleAssets",
-            "other_non_current_assets": "OtherNonCurrentAssets",
-            "current_debt_and_capital_lease_obligation": "CurrentDebtAndCapitalLeaseObligation",
-            "other_current_liabilities": "OtherCurrentLiabilities",
-            "total_non_current_liabilities_net_minority_interest": "TotalNonCurrentLiabilitiesNetMinorityInterest",
-            "non_current_deferred_liabilities": "NonCurrentDeferredLiabilities",
-            "tradeand_other_payables_non_current": "TradeandOtherPayablesNonCurrent",
-            "other_non_current_liabilities": "OtherNonCurrentLiabilities",
-            "non_current_deferred_taxes_liabilities": "NonCurrentDeferredTaxesLiabilities",
-            "non_current_deferred_revenue": "NonCurrentDeferredRevenue",
-            "share_issued": "ShareIssued",
-        }
-
-        # enumerate data frame
-        for row in df.itertuples(index=False):
-            i, created = BalanceSheet.objects.get_or_create(
-                stock=self.stock, on=row.asOfDate.date()
-            )
-
-            for key, val in mapping.items():
-                try:
-                    # value can be None
-                    tmp = float(getattr(row, val))
-                except AttributeError:
-                    tmp = 0
-
-                # if tmp is a large number, it's unlikely a rate,
-                # eg. tax rate, thus convert it to B.
-                if abs(tmp) > M:
-                    tmp = tmp / B
-
-                # set value
-                setattr(i, key, tmp)
-
-            i.save()
+class MyBalanceSheet(StatementWorker):
+    model = BalanceSheet
+    yahoo_method = "balance_sheet"
+    mapping = {
+        "ap": "AccountsPayable",
+        "cash_and_cash_equivalent": "CashAndCashEquivalents",
+        "cash_cash_equivalents_and_short_term_investments": "CashCashEquivalentsAndShortTermInvestments",
+        "common_stock": "CommonStock",
+        "common_stock_equity": "CommonStockEquity",
+        "invested_capital": "InvestedCapital",
+        "long_term_debt_and_capital_lease_obligation": "LongTermDebtAndCapitalLeaseObligation",
+        "machinery_furniture_equipment": "MachineryFurnitureEquipment",
+        "net_ppe": "NetPPE",
+        "net_tangible_assets": "NetTangibleAssets",
+        "payables": "Payables",
+        "payables_and_accrued_expenses": "PayablesAndAccruedExpenses",
+        "retained_earnings": "RetainedEarnings",
+        "stockholders_equity": "StockholdersEquity",
+        "tangible_book_value": "TangibleBookValue",
+        "total_assets": "TotalAssets",
+        "total_capitalization": "TotalCapitalization",
+        "total_debt": "TotalDebt",
+        "total_non_current_assets": "TotalNonCurrentAssets",
+        "working_capital": "WorkingCapital",
+        "gross_ppe": "GrossPPE",
+        "current_assets": "CurrentAssets",
+        "current_liabilities": "CurrentLiabilities",
+        "receivables": "Receivables",
+        "other_short_term_investments": "OtherShortTermInvestments",
+        "long_term_debt": "LongTermDebt",
+        "other_current_liabilities": "OtherCurrentLiabilities",
+        "land_and_improvements": "LandAndImprovements",
+        "ar": "AccountsReceivable",
+        "other_current_assets": "OtherCurrentAssets",
+        "investments_and_advances": "InvestmentsAndAdvances",
+        "current_debt": "CurrentDebt",
+        "inventory": "Inventory",
+        "total_tax_payable": "TotalTaxPayable",
+        "available_for_sale_securities": "AvailableForSaleSecurities",
+        "other_receivables": "OtherReceivables",
+        "other_current_borrowings": "OtherCurrentBorrowings",
+        "investmentin_financial_assets": "InvestmentinFinancialAssets",
+        "cash_equivalents": "CashEquivalents",
+        "cash_financial": "CashFinancial",
+        "commercial_paper": "CommercialPaper",
+        "current_deferred_liabilities": "CurrentDeferredLiabilities",
+        "current_deferred_revenue": "CurrentDeferredRevenue",
+        "leases": "Leases",
+        "net_debt": "NetDebt",
+        "accumulated_depreciation": "AccumulatedDepreciation",
+        "allowance_for_doubtful_accounts_receivable": "AllowanceForDoubtfulAccountsReceivable",
+        "properties": "Properties",
+        "goodwill": "Goodwill",
+        "goodwill_and_other_intangible_assets": "GoodwillAndOtherIntangibleAssets",
+        "other_intangible_assets": "OtherIntangibleAssets",
+        "other_non_current_assets": "OtherNonCurrentAssets",
+        "current_debt_and_capital_lease_obligation": "CurrentDebtAndCapitalLeaseObligation",
+        "total_non_current_liabilities_net_minority_interest": "TotalNonCurrentLiabilitiesNetMinorityInterest",
+        "non_current_deferred_liabilities": "NonCurrentDeferredLiabilities",
+        "tradeand_other_payables_non_current": "TradeandOtherPayablesNonCurrent",
+        "other_non_current_liabilities": "OtherNonCurrentLiabilities",
+        "non_current_deferred_taxes_liabilities": "NonCurrentDeferredTaxesLiabilities",
+        "non_current_deferred_revenue": "NonCurrentDeferredRevenue",
+        "share_issued": "ShareIssued",
+    }

--- a/backend/stock/workers/get_cash_flow_statement.py
+++ b/backend/stock/workers/get_cash_flow_statement.py
@@ -1,74 +1,32 @@
-import logging
-
-import pandas as pd
-
 from stock.models import CashFlow
-from stock.models import MyStock
-from yahooquery import Ticker
-
-logger = logging.getLogger("stock")
-
-M = 10 ** 6
-B = 10 ** 9
+from stock.workers.base import StatementWorker
 
 
-class MyCashFlowStatement:
-    def __init__(self, symbol):
-        self.stock = MyStock.objects.get(symbol=symbol)
-
-    def get(self):
-        s = Ticker(self.stock.symbol, timeout=15)
-
-        # all numbers convert to million
-        df = s.cash_flow(frequency="q")
-        if "unavailable" in df or "error" in df:
-            logger.error("{}: {}".format(self.stock.symbol, df))
-            return
-
-        # DB doesn't like NaN
-        df = df.where(pd.notnull(df), 0)
-        mapping = {
-            "beginning_cash": "BeginningCashPosition",
-            "ending_cash": "EndCashPosition",
-            "free_cash_flow": "FreeCashFlow",
-            "investing_cash_flow": "InvestingCashFlow",
-            "net_income": "NetIncome",
-            "operating_cash_flow": "OperatingCashFlow",
-            "da": "DepreciationAndAmortization",
-            "capex": "CapitalExpenditure",
-            "from_continuing_financing_activity": "CashFlowFromContinuingFinancingActivities",
-            "change_in_working_capital": "ChangeInWorkingCapital",
-            "stock_based_compensation": "StockBasedCompensation",
-            "change_in_cash_supplemental_as_reported": "ChangeInCashSupplementalAsReported",
-            "sale_of_investment": "SaleOfInvestment",
-            "purchase_of_investment": "PurchaseOfInvestment",
-            "common_stock_issuance": "CommonStockIssuance",
-            "repurchase_of_capital_stock": "RepurchaseOfCapitalStock",
-            "change_in_inventory": "ChangeInInventory",
-            "dividend_paid": "CashDividendsPaid",
-            "change_in_account_payable": "ChangeInAccountPayable",
-            "change_in_account_receivable": "ChangesInAccountReceivables",
-            "purchase_of_business": "PurchaseOfBusiness",
-            "net_other_financing_charges": "NetOtherFinancingCharges",
-            "net_other_investing_changes": "NetOtherInvestingChanges",
-        }
-        # enumerate data frame
-        for row in df.itertuples(index=False):
-            i, created = CashFlow.objects.get_or_create(
-                stock=self.stock, on=row.asOfDate.date()
-            )
-
-            for key, val in mapping.items():
-                try:
-                    tmp = float(getattr(row, val))
-                except AttributeError:
-                    tmp = 0
-
-                # if tmp is a large number, it's unlikely a rate,
-                # eg. tax rate, thus convert it to B.
-                if abs(tmp) > M:
-                    tmp = tmp / B
-
-                # set value
-                setattr(i, key, tmp)
-            i.save()
+class MyCashFlowStatement(StatementWorker):
+    model = CashFlow
+    yahoo_method = "cash_flow"
+    mapping = {
+        "beginning_cash": "BeginningCashPosition",
+        "ending_cash": "EndCashPosition",
+        "free_cash_flow": "FreeCashFlow",
+        "investing_cash_flow": "InvestingCashFlow",
+        "net_income": "NetIncome",
+        "operating_cash_flow": "OperatingCashFlow",
+        "da": "DepreciationAndAmortization",
+        "capex": "CapitalExpenditure",
+        "from_continuing_financing_activity": "CashFlowFromContinuingFinancingActivities",
+        "change_in_working_capital": "ChangeInWorkingCapital",
+        "stock_based_compensation": "StockBasedCompensation",
+        "change_in_cash_supplemental_as_reported": "ChangeInCashSupplementalAsReported",
+        "sale_of_investment": "SaleOfInvestment",
+        "purchase_of_investment": "PurchaseOfInvestment",
+        "common_stock_issuance": "CommonStockIssuance",
+        "repurchase_of_capital_stock": "RepurchaseOfCapitalStock",
+        "change_in_inventory": "ChangeInInventory",
+        "dividend_paid": "CashDividendsPaid",
+        "change_in_account_payable": "ChangeInAccountPayable",
+        "change_in_account_receivable": "ChangesInAccountReceivables",
+        "purchase_of_business": "PurchaseOfBusiness",
+        "net_other_financing_charges": "NetOtherFinancingCharges",
+        "net_other_investing_changes": "NetOtherInvestingChanges",
+    }

--- a/backend/stock/workers/get_income_statement.py
+++ b/backend/stock/workers/get_income_statement.py
@@ -1,85 +1,41 @@
-import logging
-
-import pandas as pd
-
 from stock.models import IncomeStatement
-from stock.models import MyStock
-from yahooquery import Ticker
-
-logger = logging.getLogger("stock")
-
-M = 10 ** 6
-B = 10 ** 9
+from stock.workers.base import StatementWorker
 
 
-class MyIncomeStatement:
-    def __init__(self, symbol):
-        self.stock = MyStock.objects.get(symbol=symbol)
-
-    def get(self):
-        s = Ticker(self.stock.symbol, timeout=15)
-
-        # all numbers convert to million
-        df = s.income_statement(frequency="q")
-        if "unavailable" in df or "error" in df:
-            logger.error("{}: {}".format(self.stock.symbol, df))
-            return
-
-        # DB doesn't like NaN
-        df = df.where(pd.notnull(df), 0)
-
-        mapping = {
-            "basic_eps": "BasicEPS",
-            "ebit": "EBIT",
-            "net_income": "NetIncome",
-            "normalized_ebitda": "NormalizedEBITDA",
-            "operating_expense": "OperatingExpense",
-            "operating_income": "OperatingIncome",
-            "operating_revenue": "OperatingRevenue",
-            "pretax_income": "PretaxIncome",
-            "selling_general_and_administration": "SellingGeneralAndAdministration",
-            "total_expenses": "TotalExpenses",
-            "total_revenue": "TotalRevenue",
-            "tax_rate": "TaxRateForCalcs",
-            "gross_profit": "GrossProfit",
-            "general_and_administrative_expense": "GeneralAndAdministrativeExpense",
-            "research_and_development": "ResearchAndDevelopment",
-            "selling_and_marketing_expense": "SellingAndMarketingExpense",
-            "total_operating_income_as_reported": "TotalOperatingIncomeAsReported",
-            "reconciled_cost_of_revenue": "ReconciledCostOfRevenue",
-            "cost_of_revenue": "CostOfRevenue",
-            "interest_expense_non_operating": "InterestExpenseNonOperating",
-            "interest_income_non_operating": "InterestIncomeNonOperating",
-            "other_income_expense": "OtherIncomeExpense",
-            "other_non_operating_income_expenses": "OtherNonOperatingIncomeExpenses",
-            "tax_provision": "TaxProvision",
-            "net_income_common_stockholders": "NetIncomeCommonStockholders",
-            "net_income_from_continuing_and_discontinued_operation": "NetIncomeFromContinuingAndDiscontinuedOperation",
-            "interest_income": "InterestIncome",
-            "interest_expense": "InterestExpense",
-            "net_interest_income": "NetInterestIncome",
-            "ebitda": "EBITDA",
-            "reconciled_depreciation": "ReconciledDepreciation",
-            "net_income_from_continuing_operation_net_minority_interest": "NetIncomeFromContinuingOperationNetMinorityInterest",
-        }
-        # enumerate data frame
-        for row in df.itertuples(index=False):
-            i, created = IncomeStatement.objects.get_or_create(
-                stock=self.stock, on=row.asOfDate.date()
-            )
-
-            for key, val in mapping.items():
-                try:
-                    tmp = float(getattr(row, val))
-                except AttributeError:
-                    tmp = 0
-
-                # if tmp is a large number, it's unlikely a rate,
-                # eg. tax rate, thus convert it to B.
-                if abs(tmp) > M:
-                    tmp = tmp / B
-
-                # set value
-                setattr(i, key, tmp)
-
-            i.save()
+class MyIncomeStatement(StatementWorker):
+    model = IncomeStatement
+    yahoo_method = "income_statement"
+    mapping = {
+        "basic_eps": "BasicEPS",
+        "ebit": "EBIT",
+        "net_income": "NetIncome",
+        "normalized_ebitda": "NormalizedEBITDA",
+        "operating_expense": "OperatingExpense",
+        "operating_income": "OperatingIncome",
+        "operating_revenue": "OperatingRevenue",
+        "pretax_income": "PretaxIncome",
+        "selling_general_and_administration": "SellingGeneralAndAdministration",
+        "total_expenses": "TotalExpenses",
+        "total_revenue": "TotalRevenue",
+        "tax_rate": "TaxRateForCalcs",
+        "gross_profit": "GrossProfit",
+        "general_and_administrative_expense": "GeneralAndAdministrativeExpense",
+        "research_and_development": "ResearchAndDevelopment",
+        "selling_and_marketing_expense": "SellingAndMarketingExpense",
+        "total_operating_income_as_reported": "TotalOperatingIncomeAsReported",
+        "reconciled_cost_of_revenue": "ReconciledCostOfRevenue",
+        "cost_of_revenue": "CostOfRevenue",
+        "interest_expense_non_operating": "InterestExpenseNonOperating",
+        "interest_income_non_operating": "InterestIncomeNonOperating",
+        "other_income_expense": "OtherIncomeExpense",
+        "other_non_operating_income_expenses": "OtherNonOperatingIncomeExpenses",
+        "tax_provision": "TaxProvision",
+        "net_income_common_stockholders": "NetIncomeCommonStockholders",
+        "net_income_from_continuing_and_discontinued_operation": "NetIncomeFromContinuingAndDiscontinuedOperation",
+        "interest_income": "InterestIncome",
+        "interest_expense": "InterestExpense",
+        "net_interest_income": "NetInterestIncome",
+        "ebitda": "EBITDA",
+        "reconciled_depreciation": "ReconciledDepreciation",
+        "net_income_from_continuing_operation_net_minority_interest": "NetIncomeFromContinuingOperationNetMinorityInterest",
+    }

--- a/backend/stock/workers/get_valuation_ratio.py
+++ b/backend/stock/workers/get_valuation_ratio.py
@@ -1,55 +1,21 @@
-import logging
-
-import pandas as pd
-
-from stock.models import MyStock
 from stock.models import ValuationRatio
-from yahooquery import Ticker
-
-logger = logging.getLogger("stock")
+from stock.workers.base import StatementWorker
 
 
-class MyValuationRatio:
-    def __init__(self, symbol):
-        self.stock = MyStock.objects.get(symbol=symbol)
+class MyValuationRatio(StatementWorker):
+    model = ValuationRatio
+    yahoo_method = "valuation_measures"
+    frequency = None  # valuation_measures is a property, not a method with frequency
+    normalize_large = False
+    mapping = {
+        "forward_pe": "ForwardPeRatio",
+        "pb": "PbRatio",
+        "pe": "PeRatio",
+        "peg": "PegRatio",
+        "ps": "PsRatio",
+    }
 
-    def get(self):
-        s = Ticker(self.stock.symbol, timeout=15)
-
-        # all numbers convert to million
-        df = s.valuation_measures
-        if "unavailable" in df or "error" in df:
-            logger.error("{}: {}".format(self.stock.symbol, df))
-            return
-
-        # DB doesn't like NaN
-        df = df.where(pd.notnull(df), 0)
-
-        mapping = {
-            "forward_pe": "ForwardPeRatio",
-            "pb": "PbRatio",
-            "pe": "PeRatio",
-            "peg": "PegRatio",
-            "ps": "PsRatio",
-        }
-
-        # enumerate data frame
-        for row in df.itertuples(index=False):
-            i, created = ValuationRatio.objects.get_or_create(
-                stock=self.stock, on=row.asOfDate.date()
-            )
-
-            for key, val in mapping.items():
-                try:
-                    tmp = float(getattr(row, val))
-                except AttributeError:
-                    tmp = 0
-
-                # set value
-                setattr(i, key, tmp)
-            i.save()
-
-        # if all values are 0, discard the record
-        ValuationRatio.objects.filter(
-            forward_pe=0, pb=0, pe=0, peg=0, ps=0
-        ).delete()
+    def post_save(self, instance):
+        """Remove records where all values are 0."""
+        if not any([instance.forward_pe, instance.pb, instance.pe, instance.peg, instance.ps]):
+            instance.delete()


### PR DESCRIPTION
Step 1.7 — Reduce duplication.

- Create StatementWorker base with shared get() logic and post_save() hook
- 4 workers now inherit: only define model, mapping, yahoo_method
- 4x150 lines → 1x70 + 4x30 lines (net -94)
- Tested: AAPL balance sheet fetch, all API endpoints, full task chain