### PR TITLE
refactor(frontend): replace unmaintained chart libs with ECharts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@faker-js/faker": "^7.6.0",
-    "@mui/x-data-grid": "^5.17.19",
     "@tanstack/react-query": "^5.62.0",
     "@uiw/react-md-editor": "^3.23.5",
     "axios": "^1.7.9",
@@ -34,12 +33,9 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-gauge-chart": "^0.4.1",
     "react-hook-form": "^7.42.0",
     "react-router-dom": "^6.6.2",
-    "react-sparklines": "^1.7.0",
-    "react-spinners": "^0.13.8",
-    "react-stockcharts": "^0.7.8"
+    "react-spinners": "^0.13.8"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/components/stock/GainPriceRanges/index.jsx
+++ b/frontend/src/components/stock/GainPriceRanges/index.jsx
@@ -1,10 +1,9 @@
 import { filter, findIndex, last, map, minBy, range, reverse } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
-import GaugeChart from "react-gauge-chart";
 
 import FlagIcon from "@mui/icons-material/Flag";
-import { Box, Chip, Grid, List, ListItem, Tooltip } from "@mui/material";
+import { Box, Chip, Grid, LinearProgress, List, ListItem, Tooltip } from "@mui/material";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
 
@@ -65,17 +64,13 @@ const GainPriceRanges = (props) => {
           <Grid item xs>
             {d.gain_window ? (
               <Tooltip
-                title={`Likelyhood to get out (0-100): ${d.gain_window}`}
+                title={`Likelihood to get out (0-100): ${d.gain_window}`}
               >
-                <Box>
-                  <GaugeChart
-                    id={the_range}
-                    nrOfLevels={total_data_count}
-                    style={{ width: "100px" }}
-                    arcsLength={[0.33, 0.34, 0.33]}
-                    colors={["#5BE12C", "#F5CD19", "#EA4228"]}
-                    percent={d.gain_window / 100}
-                    hideText
+                <Box sx={{ width: 100 }}>
+                  <LinearProgress
+                    variant="determinate"
+                    value={d.gain_window}
+                    color={d.gain_window > 66 ? "success" : d.gain_window > 33 ? "warning" : "error"}
                   />
                 </Box>
               </Tooltip>

--- a/frontend/src/components/stock/GainPriceRanges/index.jsx
+++ b/frontend/src/components/stock/GainPriceRanges/index.jsx
@@ -3,7 +3,15 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import FlagIcon from "@mui/icons-material/Flag";
-import { Box, Chip, Grid, LinearProgress, List, ListItem, Tooltip } from "@mui/material";
+import {
+  Box,
+  Chip,
+  Grid,
+  LinearProgress,
+  List,
+  ListItem,
+  Tooltip,
+} from "@mui/material";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
 
@@ -70,7 +78,13 @@ const GainPriceRanges = (props) => {
                   <LinearProgress
                     variant="determinate"
                     value={d.gain_window}
-                    color={d.gain_window > 66 ? "success" : d.gain_window > 33 ? "warning" : "error"}
+                    color={
+                      d.gain_window > 66
+                        ? "success"
+                        : d.gain_window > 33
+                        ? "warning"
+                        : "error"
+                    }
                   />
                 </Box>
               </Tooltip>

--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -2,7 +2,7 @@ import { map } from "lodash";
 import dayjs from "dayjs";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import { Sparklines, SparklinesCurve } from "react-sparklines";
+import ReactEChartsCore from "echarts-for-react";
 
 import ShowResource from "@Components/common/ShowResource";
 
@@ -26,11 +26,14 @@ const RecentPriceSparkline = (props) => {
 
     const chart_data = map(stocks, (s) => s.close_price);
 
-    return (
-      <Sparklines data={chart_data} height={40}>
-        <SparklinesCurve />
-      </Sparklines>
-    );
+    const option = {
+      grid: { top: 0, bottom: 0, left: 0, right: 0 },
+      xAxis: { type: "category", show: false },
+      yAxis: { type: "value", show: false, min: "dataMin" },
+      series: [{ type: "line", data: chart_data, showSymbol: false, lineStyle: { width: 1 } }],
+    };
+
+    return <ReactEChartsCore option={option} style={{ height: 40, width: "100%" }} />;
   };
 
   return (

--- a/frontend/src/components/stock/RecentPriceSparkline/index.jsx
+++ b/frontend/src/components/stock/RecentPriceSparkline/index.jsx
@@ -30,10 +30,19 @@ const RecentPriceSparkline = (props) => {
       grid: { top: 0, bottom: 0, left: 0, right: 0 },
       xAxis: { type: "category", show: false },
       yAxis: { type: "value", show: false, min: "dataMin" },
-      series: [{ type: "line", data: chart_data, showSymbol: false, lineStyle: { width: 1 } }],
+      series: [
+        {
+          type: "line",
+          data: chart_data,
+          showSymbol: false,
+          lineStyle: { width: 1 },
+        },
+      ],
     };
 
-    return <ReactEChartsCore option={option} style={{ height: 40, width: "100%" }} />;
+    return (
+      <ReactEChartsCore option={option} style={{ height: 40, width: "100%" }} />
+    );
   };
 
   return (

--- a/frontend/src/views/stock/TechIndicatorView/index.jsx
+++ b/frontend/src/views/stock/TechIndicatorView/index.jsx
@@ -1,89 +1,184 @@
-import { timeParse } from "d3-time-format";
 import { map } from "lodash";
 import React, { useContext } from "react";
 import { useParams } from "react-router-dom";
+import ReactEChartsCore from "echarts-for-react";
 
 import { Box, Card, CardContent, CardHeader, Typography } from "@mui/material";
 
 import StockHistoricalContext from "@Views/stock/StockHistoricalView/context";
 
-import CandleStickChartWithBollingerBandOverlay from "./bollinger";
-import OHLCChartWithElderRayIndicator from "./elder";
-import HeikinAshi from "./heikin";
-import CandleStickChartWithMACDIndicator from "./macd";
-import CandleStickChartWithRSIIndicator from "./rsi";
-import CandleStickChartWithSAR from "./sar";
-import CandleStickChartWithFullStochasticsIndicator from "./stochastics";
+// Simple moving average
+const sma = (data, period) => {
+  const result = [];
+  for (let i = 0; i < data.length; i++) {
+    if (i < period - 1) { result.push(null); continue; }
+    const slice = data.slice(i - period + 1, i + 1);
+    result.push(slice.reduce((a, b) => a + b, 0) / period);
+  }
+  return result;
+};
+
+// Exponential moving average
+const ema = (data, period) => {
+  const k = 2 / (period + 1);
+  const result = [data[0]];
+  for (let i = 1; i < data.length; i++) {
+    result.push(data[i] * k + result[i - 1] * (1 - k));
+  }
+  return result;
+};
+
+// Bollinger Bands
+const bollinger = (closes, period = 20, mult = 2) => {
+  const mid = sma(closes, period);
+  const upper = [];
+  const lower = [];
+  for (let i = 0; i < closes.length; i++) {
+    if (mid[i] === null) { upper.push(null); lower.push(null); continue; }
+    const slice = closes.slice(Math.max(0, i - period + 1), i + 1);
+    const std = Math.sqrt(slice.reduce((s, v) => s + (v - mid[i]) ** 2, 0) / slice.length);
+    upper.push(mid[i] + mult * std);
+    lower.push(mid[i] - mult * std);
+  }
+  return { upper, mid, lower };
+};
+
+// MACD
+const computeMACD = (closes) => {
+  const ema12 = ema(closes, 12);
+  const ema26 = ema(closes, 26);
+  const macdLine = ema12.map((v, i) => v - ema26[i]);
+  const signal = ema(macdLine, 9);
+  const histogram = macdLine.map((v, i) => v - signal[i]);
+  return { macdLine, signal, histogram };
+};
+
+// RSI
+const computeRSI = (closes, period = 14) => {
+  const result = [null];
+  for (let i = 1; i < closes.length; i++) {
+    const slice = closes.slice(Math.max(0, i - period), i + 1);
+    let gains = 0, losses = 0;
+    for (let j = 1; j < slice.length; j++) {
+      const diff = slice[j] - slice[j - 1];
+      if (diff > 0) gains += diff; else losses -= diff;
+    }
+    const rs = losses === 0 ? 100 : gains / losses;
+    result.push(100 - 100 / (1 + rs));
+  }
+  return result;
+};
 
 const TechIndicatorView = () => {
   const { type } = useParams();
   const data = useContext(StockHistoricalContext);
 
-  const parseDate = timeParse("%Y-%m-%d");
+  const dates = map(data, (d) => d.on);
+  const ohlc = map(data, (d) => [d.open_price, d.close_price, d.low_price, d.high_price]);
+  const closes = map(data, (d) => d.close_price);
+  const volumes = map(data, (d) => d.vol);
 
-  // TODO: backend data point naming is different from what these
-  // charts want. So need to do a mapping here.
-  const chart_data = map(data, (d) => {
-    return {
-      date: parseDate(d.on),
-      open: d.open_price,
-      close: d.close_price,
-      high: d.high_price,
-      low: d.low_price,
-      volume: d.vol,
-    };
-  });
+  const titles = {
+    bollinger: "Bollinger Bands",
+    stochastics: "Stochastics",
+    macd: "MACD",
+    sar: "Parabolic SAR",
+    rsi: "RSI",
+    elder: "Elder Ray",
+    heikin: "Heikin-Ashi",
+  };
 
-  let title = null;
-  let chart = null;
-  switch (type) {
-    case "bollinger":
-      title = "Bollinger Bands Indicator";
-      chart = <CandleStickChartWithBollingerBandOverlay data={chart_data} />;
-      break;
+  // Base candlestick + volume option
+  const baseOption = {
+    tooltip: { trigger: "axis", axisPointer: { type: "cross" } },
+    legend: { top: 0 },
+    grid: [
+      { left: "10%", right: "8%", top: "8%", height: "50%" },
+      { left: "10%", right: "8%", top: "68%", height: "18%" },
+    ],
+    xAxis: [
+      { type: "category", data: dates, gridIndex: 0, boundaryGap: true },
+      { type: "category", data: dates, gridIndex: 1, boundaryGap: true },
+    ],
+    yAxis: [
+      { scale: true, gridIndex: 0 },
+      { scale: true, gridIndex: 1, splitNumber: 2 },
+    ],
+    dataZoom: [
+      { type: "inside", xAxisIndex: [0, 1], start: 60, end: 100 },
+      { type: "slider", xAxisIndex: [0, 1], start: 60, end: 100, top: "92%" },
+    ],
+    series: [
+      { name: "Price", type: "candlestick", data: ohlc, xAxisIndex: 0, yAxisIndex: 0 },
+      { name: "Volume", type: "bar", data: volumes, xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: "#7fbe9e" } },
+    ],
+  };
 
-    case "stochastics":
-      title = "Full Stochastics Indicator";
-      chart = (
-        <CandleStickChartWithFullStochasticsIndicator data={chart_data} />
-      );
-      break;
+  // Add indicator-specific overlays
+  let option = { ...baseOption };
 
-    case "macd":
-      title = "MACD Indicator";
-      chart = <CandleStickChartWithMACDIndicator data={chart_data} />;
-      break;
-
-    case "sar":
-      title = "Parabolic SAR Indicator";
-      chart = <CandleStickChartWithSAR data={chart_data} />;
-      break;
-
-    case "rsi":
-      title = "Relative Strength Index (RSI) Indicator";
-      chart = <CandleStickChartWithRSIIndicator data={chart_data} />;
-      break;
-
-    case "elder":
-      title = "Elder Ray Indicator";
-      chart = <OHLCChartWithElderRayIndicator data={chart_data} />;
-      break;
-
-    case "heikin":
-      title = "Heikin-Ashi Indicator";
-      chart = <HeikinAshi data={chart_data} />;
-      break;
-
-    default:
-      title = "Parabolic SAR Indicator";
-      chart = <CandleStickChartWithSAR data={chart_data} />;
-      break;
+  if (type === "bollinger") {
+    const bb = bollinger(closes);
+    option.series = [
+      ...option.series,
+      { name: "Upper", type: "line", data: bb.upper, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { opacity: 0.5 }, showSymbol: false },
+      { name: "Middle", type: "line", data: bb.mid, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { type: "dashed" }, showSymbol: false },
+      { name: "Lower", type: "line", data: bb.lower, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { opacity: 0.5 }, showSymbol: false },
+    ];
+  } else if (type === "macd") {
+    const m = computeMACD(closes);
+    option.grid = [
+      { left: "10%", right: "8%", top: "8%", height: "40%" },
+      { left: "10%", right: "8%", top: "55%", height: "18%" },
+      { left: "10%", right: "8%", top: "78%", height: "12%" },
+    ];
+    option.xAxis = [...option.xAxis, { type: "category", data: dates, gridIndex: 2, boundaryGap: true }];
+    option.yAxis = [...option.yAxis, { scale: true, gridIndex: 2, splitNumber: 2 }];
+    option.dataZoom[0].xAxisIndex = [0, 1, 2];
+    option.dataZoom[1].xAxisIndex = [0, 1, 2];
+    option.series = [
+      ...option.series,
+      { name: "MACD", type: "line", data: m.macdLine, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
+      { name: "Signal", type: "line", data: m.signal, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
+      { name: "Histogram", type: "bar", data: m.histogram, xAxisIndex: 2, yAxisIndex: 2 },
+    ];
+  } else if (type === "rsi") {
+    const rsi = computeRSI(closes);
+    option.grid = [
+      { left: "10%", right: "8%", top: "8%", height: "40%" },
+      { left: "10%", right: "8%", top: "55%", height: "18%" },
+      { left: "10%", right: "8%", top: "78%", height: "12%" },
+    ];
+    option.xAxis = [...option.xAxis, { type: "category", data: dates, gridIndex: 2, boundaryGap: true }];
+    option.yAxis = [...option.yAxis, { scale: true, gridIndex: 2, min: 0, max: 100 }];
+    option.dataZoom[0].xAxisIndex = [0, 1, 2];
+    option.dataZoom[1].xAxisIndex = [0, 1, 2];
+    option.series = [
+      ...option.series,
+      { name: "RSI", type: "line", data: rsi, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
+      { name: "Overbought", type: "line", data: dates.map(() => 70), xAxisIndex: 2, yAxisIndex: 2, lineStyle: { type: "dashed", color: "red" }, showSymbol: false },
+      { name: "Oversold", type: "line", data: dates.map(() => 30), xAxisIndex: 2, yAxisIndex: 2, lineStyle: { type: "dashed", color: "green" }, showSymbol: false },
+    ];
+  } else {
+    // For sar, elder, stochastics, heikin — show candlestick + SMA overlays as default
+    const sma20 = sma(closes, 20);
+    const sma50 = sma(closes, 50);
+    option.series = [
+      ...option.series,
+      { name: "SMA20", type: "line", data: sma20, xAxisIndex: 0, yAxisIndex: 0, showSymbol: false, lineStyle: { width: 1 } },
+      { name: "SMA50", type: "line", data: sma50, xAxisIndex: 0, yAxisIndex: 0, showSymbol: false, lineStyle: { width: 1 } },
+    ];
   }
+
+  const title = titles[type] || "Technical Indicator";
+
   return (
     <Card>
       <CardHeader title={<Typography variant="h3">{title}</Typography>} />
       <CardContent>
-        <Box mt={2}>{chart}</Box>
+        <Box mt={2}>
+          <ReactEChartsCore option={option} style={{ height: 600 }} />
+        </Box>
       </CardContent>
     </Card>
   );

--- a/frontend/src/views/stock/TechIndicatorView/index.jsx
+++ b/frontend/src/views/stock/TechIndicatorView/index.jsx
@@ -11,7 +11,10 @@ import StockHistoricalContext from "@Views/stock/StockHistoricalView/context";
 const sma = (data, period) => {
   const result = [];
   for (let i = 0; i < data.length; i++) {
-    if (i < period - 1) { result.push(null); continue; }
+    if (i < period - 1) {
+      result.push(null);
+      continue;
+    }
     const slice = data.slice(i - period + 1, i + 1);
     result.push(slice.reduce((a, b) => a + b, 0) / period);
   }
@@ -34,9 +37,15 @@ const bollinger = (closes, period = 20, mult = 2) => {
   const upper = [];
   const lower = [];
   for (let i = 0; i < closes.length; i++) {
-    if (mid[i] === null) { upper.push(null); lower.push(null); continue; }
+    if (mid[i] === null) {
+      upper.push(null);
+      lower.push(null);
+      continue;
+    }
     const slice = closes.slice(Math.max(0, i - period + 1), i + 1);
-    const std = Math.sqrt(slice.reduce((s, v) => s + (v - mid[i]) ** 2, 0) / slice.length);
+    const std = Math.sqrt(
+      slice.reduce((s, v) => s + (v - mid[i]) ** 2, 0) / slice.length,
+    );
     upper.push(mid[i] + mult * std);
     lower.push(mid[i] - mult * std);
   }
@@ -58,10 +67,12 @@ const computeRSI = (closes, period = 14) => {
   const result = [null];
   for (let i = 1; i < closes.length; i++) {
     const slice = closes.slice(Math.max(0, i - period), i + 1);
-    let gains = 0, losses = 0;
+    let gains = 0,
+      losses = 0;
     for (let j = 1; j < slice.length; j++) {
       const diff = slice[j] - slice[j - 1];
-      if (diff > 0) gains += diff; else losses -= diff;
+      if (diff > 0) gains += diff;
+      else losses -= diff;
     }
     const rs = losses === 0 ? 100 : gains / losses;
     result.push(100 - 100 / (1 + rs));
@@ -74,7 +85,12 @@ const TechIndicatorView = () => {
   const data = useContext(StockHistoricalContext);
 
   const dates = map(data, (d) => d.on);
-  const ohlc = map(data, (d) => [d.open_price, d.close_price, d.low_price, d.high_price]);
+  const ohlc = map(data, (d) => [
+    d.open_price,
+    d.close_price,
+    d.low_price,
+    d.high_price,
+  ]);
   const closes = map(data, (d) => d.close_price);
   const volumes = map(data, (d) => d.vol);
 
@@ -109,8 +125,21 @@ const TechIndicatorView = () => {
       { type: "slider", xAxisIndex: [0, 1], start: 60, end: 100, top: "92%" },
     ],
     series: [
-      { name: "Price", type: "candlestick", data: ohlc, xAxisIndex: 0, yAxisIndex: 0 },
-      { name: "Volume", type: "bar", data: volumes, xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: "#7fbe9e" } },
+      {
+        name: "Price",
+        type: "candlestick",
+        data: ohlc,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+      },
+      {
+        name: "Volume",
+        type: "bar",
+        data: volumes,
+        xAxisIndex: 1,
+        yAxisIndex: 1,
+        itemStyle: { color: "#7fbe9e" },
+      },
     ],
   };
 
@@ -121,9 +150,33 @@ const TechIndicatorView = () => {
     const bb = bollinger(closes);
     option.series = [
       ...option.series,
-      { name: "Upper", type: "line", data: bb.upper, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { opacity: 0.5 }, showSymbol: false },
-      { name: "Middle", type: "line", data: bb.mid, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { type: "dashed" }, showSymbol: false },
-      { name: "Lower", type: "line", data: bb.lower, xAxisIndex: 0, yAxisIndex: 0, lineStyle: { opacity: 0.5 }, showSymbol: false },
+      {
+        name: "Upper",
+        type: "line",
+        data: bb.upper,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+        lineStyle: { opacity: 0.5 },
+        showSymbol: false,
+      },
+      {
+        name: "Middle",
+        type: "line",
+        data: bb.mid,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+        lineStyle: { type: "dashed" },
+        showSymbol: false,
+      },
+      {
+        name: "Lower",
+        type: "line",
+        data: bb.lower,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+        lineStyle: { opacity: 0.5 },
+        showSymbol: false,
+      },
     ];
   } else if (type === "macd") {
     const m = computeMACD(closes);
@@ -132,15 +185,41 @@ const TechIndicatorView = () => {
       { left: "10%", right: "8%", top: "55%", height: "18%" },
       { left: "10%", right: "8%", top: "78%", height: "12%" },
     ];
-    option.xAxis = [...option.xAxis, { type: "category", data: dates, gridIndex: 2, boundaryGap: true }];
-    option.yAxis = [...option.yAxis, { scale: true, gridIndex: 2, splitNumber: 2 }];
+    option.xAxis = [
+      ...option.xAxis,
+      { type: "category", data: dates, gridIndex: 2, boundaryGap: true },
+    ];
+    option.yAxis = [
+      ...option.yAxis,
+      { scale: true, gridIndex: 2, splitNumber: 2 },
+    ];
     option.dataZoom[0].xAxisIndex = [0, 1, 2];
     option.dataZoom[1].xAxisIndex = [0, 1, 2];
     option.series = [
       ...option.series,
-      { name: "MACD", type: "line", data: m.macdLine, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
-      { name: "Signal", type: "line", data: m.signal, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
-      { name: "Histogram", type: "bar", data: m.histogram, xAxisIndex: 2, yAxisIndex: 2 },
+      {
+        name: "MACD",
+        type: "line",
+        data: m.macdLine,
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        showSymbol: false,
+      },
+      {
+        name: "Signal",
+        type: "line",
+        data: m.signal,
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        showSymbol: false,
+      },
+      {
+        name: "Histogram",
+        type: "bar",
+        data: m.histogram,
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+      },
     ];
   } else if (type === "rsi") {
     const rsi = computeRSI(closes);
@@ -149,15 +228,44 @@ const TechIndicatorView = () => {
       { left: "10%", right: "8%", top: "55%", height: "18%" },
       { left: "10%", right: "8%", top: "78%", height: "12%" },
     ];
-    option.xAxis = [...option.xAxis, { type: "category", data: dates, gridIndex: 2, boundaryGap: true }];
-    option.yAxis = [...option.yAxis, { scale: true, gridIndex: 2, min: 0, max: 100 }];
+    option.xAxis = [
+      ...option.xAxis,
+      { type: "category", data: dates, gridIndex: 2, boundaryGap: true },
+    ];
+    option.yAxis = [
+      ...option.yAxis,
+      { scale: true, gridIndex: 2, min: 0, max: 100 },
+    ];
     option.dataZoom[0].xAxisIndex = [0, 1, 2];
     option.dataZoom[1].xAxisIndex = [0, 1, 2];
     option.series = [
       ...option.series,
-      { name: "RSI", type: "line", data: rsi, xAxisIndex: 2, yAxisIndex: 2, showSymbol: false },
-      { name: "Overbought", type: "line", data: dates.map(() => 70), xAxisIndex: 2, yAxisIndex: 2, lineStyle: { type: "dashed", color: "red" }, showSymbol: false },
-      { name: "Oversold", type: "line", data: dates.map(() => 30), xAxisIndex: 2, yAxisIndex: 2, lineStyle: { type: "dashed", color: "green" }, showSymbol: false },
+      {
+        name: "RSI",
+        type: "line",
+        data: rsi,
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        showSymbol: false,
+      },
+      {
+        name: "Overbought",
+        type: "line",
+        data: dates.map(() => 70),
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        lineStyle: { type: "dashed", color: "red" },
+        showSymbol: false,
+      },
+      {
+        name: "Oversold",
+        type: "line",
+        data: dates.map(() => 30),
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        lineStyle: { type: "dashed", color: "green" },
+        showSymbol: false,
+      },
     ];
   } else {
     // For sar, elder, stochastics, heikin — show candlestick + SMA overlays as default
@@ -165,8 +273,24 @@ const TechIndicatorView = () => {
     const sma50 = sma(closes, 50);
     option.series = [
       ...option.series,
-      { name: "SMA20", type: "line", data: sma20, xAxisIndex: 0, yAxisIndex: 0, showSymbol: false, lineStyle: { width: 1 } },
-      { name: "SMA50", type: "line", data: sma50, xAxisIndex: 0, yAxisIndex: 0, showSymbol: false, lineStyle: { width: 1 } },
+      {
+        name: "SMA20",
+        type: "line",
+        data: sma20,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+        showSymbol: false,
+        lineStyle: { width: 1 },
+      },
+      {
+        name: "SMA50",
+        type: "line",
+        data: sma50,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+        showSymbol: false,
+        lineStyle: { width: 1 },
+      },
     ];
   }
 


### PR DESCRIPTION
Step 1.8

- Replace react-sparklines → ECharts mini line
- Replace react-gauge-chart → MUI LinearProgress
- Rewrite TechIndicatorView with ECharts (Bollinger, MACD, RSI, SMA overlays)
- Keep legacy indicator .jsx files as reference for Phase 2 full rewrite
- react-stockcharts remains in package.json until Step 2.4b