### PR TITLE
refactor(frontend): rewrite Get/PollResource with react-query + fix data patterns

### DIFF
--- a/frontend/src/components/common/Get/index.jsx
+++ b/frontend/src/components/common/Get/index.jsx
@@ -1,41 +1,22 @@
-import React, { useEffect, useState } from "react";
-
+import React from "react";
 import PropTypes from "prop-types";
 import ScaleLoader from "react-spinners/ScaleLoader";
+import { useQuery } from "@tanstack/react-query";
 
 import api from "@/api/client";
 
 const Get = ({ uri, on_success, on_error, silent }) => {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["get", uri],
+    queryFn: () =>
+      api.get(encodeURI(uri)).then((r) => {
+        const d = r.data;
+        return d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
+      }),
+    enabled: !!uri,
+  });
 
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .get(encodeURI(uri))
-      .then((r) => {
-        if (!cancelled) {
-          // Normalize paginated responses
-          const d = r.data;
-          const normalized =
-            d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
-          setData(normalized);
-          setLoading(false);
-        }
-      })
-      .catch((e) => {
-        if (!cancelled) {
-          setError(e);
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [uri]);
-
-  if (loading) return silent ? null : <ScaleLoader loading />;
+  if (isLoading) return silent ? null : <ScaleLoader loading />;
   if (error) return on_error ? on_error(error) : null;
   return on_success ? on_success(data) : null;
 };

--- a/frontend/src/components/common/Get/index.jsx
+++ b/frontend/src/components/common/Get/index.jsx
@@ -11,7 +11,9 @@ const Get = ({ uri, on_success, on_error, silent }) => {
     queryFn: () =>
       api.get(encodeURI(uri)).then((r) => {
         const d = r.data;
-        return d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
+        return d && !Array.isArray(d) && Array.isArray(d.results)
+          ? d.results
+          : d;
       }),
     enabled: !!uri,
   });

--- a/frontend/src/components/common/PollResource/index.jsx
+++ b/frontend/src/components/common/PollResource/index.jsx
@@ -11,7 +11,9 @@ const PollResource = ({ resource, on_success, interval = 10, silent }) => {
     queryFn: () =>
       api.get(encodeURI(resource)).then((r) => {
         const d = r.data;
-        return d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
+        return d && !Array.isArray(d) && Array.isArray(d.results)
+          ? d.results
+          : d;
       }),
     enabled: !!resource,
     refetchInterval: interval * 1000,

--- a/frontend/src/components/common/PollResource/index.jsx
+++ b/frontend/src/components/common/PollResource/index.jsx
@@ -1,32 +1,23 @@
-import React, { useEffect, useRef, useState } from "react";
-
+import React from "react";
 import PropTypes from "prop-types";
 import ScaleLoader from "react-spinners/ScaleLoader";
+import { useQuery } from "@tanstack/react-query";
 
 import api from "@/api/client";
 
 const PollResource = ({ resource, on_success, interval = 10, silent }) => {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const timerRef = useRef(null);
+  const { data, isLoading } = useQuery({
+    queryKey: ["poll", resource],
+    queryFn: () =>
+      api.get(encodeURI(resource)).then((r) => {
+        const d = r.data;
+        return d && !Array.isArray(d) && Array.isArray(d.results) ? d.results : d;
+      }),
+    enabled: !!resource,
+    refetchInterval: interval * 1000,
+  });
 
-  const fetchData = () => {
-    api
-      .get(encodeURI(resource))
-      .then((r) => {
-        setData(r.data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    fetchData();
-    timerRef.current = setInterval(fetchData, interval * 1000);
-    return () => clearInterval(timerRef.current);
-  }, [resource, interval]);
-
-  if (loading) return silent ? null : <ScaleLoader loading />;
+  if (isLoading) return silent ? null : <ScaleLoader loading />;
   return on_success ? on_success(data) : null;
 };
 

--- a/frontend/src/components/diary/ListDiary/index.jsx
+++ b/frontend/src/components/diary/ListDiary/index.jsx
@@ -40,7 +40,7 @@ const ListDiary = (props) => {
   );
 
   const render_data = (resp) => {
-    const diaries = resp.objects;
+    const diaries = Array.isArray(resp) ? resp : resp.objects || [];
 
     const diary_entries = map(diaries, (d) => (
       <Box key={d.id} mb={2}>

--- a/frontend/src/components/news/ListNewsCard/index.jsx
+++ b/frontend/src/components/news/ListNewsCard/index.jsx
@@ -60,7 +60,7 @@ const ListNewsCard = (props) => {
   const render_data = (resp) => {
     const what_is_next = resp.meta.next;
 
-    const news = resp.objects;
+    const news = Array.isArray(resp) ? resp : resp.objects || [];
 
     const news_list = map(news, (n) => {
       return (

--- a/frontend/src/components/sector/SectorStatementComparisonCharts/index.jsx
+++ b/frontend/src/components/sector/SectorStatementComparisonCharts/index.jsx
@@ -14,7 +14,7 @@ const SectorStatementComparisonCharts = (props) => {
   const to_ignore_list = ["on", "id", "symbol", "resource_uri", "stock"];
 
   const render_data = (resp) => {
-    const data = resp.objects;
+    const data = Array.isArray(resp) ? resp : resp.objects || [];
     const attrs = Object.keys(data[0]);
     attrs.sort();
 

--- a/frontend/src/components/task/TaskResult/index.jsx
+++ b/frontend/src/components/task/TaskResult/index.jsx
@@ -14,7 +14,7 @@ const TaskResult = (props) => {
 
   // render
   const render_data = (data) => {
-    const { objects: results } = data;
+    const results = Array.isArray(data) ? data : data.objects || [];
 
     const result = results[0];
 

--- a/frontend/src/lib/storybook/index.jsx
+++ b/frontend/src/lib/storybook/index.jsx
@@ -219,32 +219,81 @@ export const DictCard = ({ data, interests, title }) => {
 };
 
 // DictTable
-export const DictTable = ({ data, title }) => (
-  <Box>
-    {title && <Typography variant="h6">{title}</Typography>}
-    <table style={{ width: "100%", borderCollapse: "collapse" }}>
-      <tbody>
-        {data &&
-          Object.entries(data).map(([k, v]) => (
-            <tr key={k}>
-              <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>
-                {k}
-              </td>
-              <td
-                style={{
-                  padding: 4,
-                  borderBottom: "1px solid #eee",
-                  textAlign: "right",
-                }}
-              >
-                {String(v)}
-              </td>
-            </tr>
-          ))}
-      </tbody>
-    </table>
-  </Box>
-);
+export const DictTable = ({ data, title, interests, chart }) => {
+  // If data is an array of objects with 'on' field (financial statements), render time-series table
+  if (Array.isArray(data) && data.length > 0 && data[0].on && interests) {
+    const fields = Object.entries(interests); // [[fieldKey, label], ...]
+    return (
+      <Box>
+        {title && <Typography variant="h6">{title}</Typography>}
+        <Box sx={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.85rem" }}>
+            <thead>
+              <tr>
+                <th style={{ padding: 4, textAlign: "left" }}>Metric</th>
+                {data.map((d) => (
+                  <th key={d.on} style={{ padding: 4, textAlign: "right" }}>{d.on}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {fields.map(([key, label]) => (
+                <tr key={key}>
+                  <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>{label}</td>
+                  {data.map((d) => (
+                    <td key={d.on} style={{ padding: 4, borderBottom: "1px solid #eee", textAlign: "right" }}>
+                      {d[key] != null ? (typeof d[key] === "number" ? d[key].toFixed(4) : String(d[key])) : "-"}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Box>
+        {chart && data.length > 1 && interests && (
+          <Box mt={2}>
+            <ReactEChartsCore
+              option={{
+                tooltip: { trigger: "axis" },
+                legend: { data: fields.slice(0, 5).map(([, l]) => l) },
+                xAxis: { type: "category", data: data.map((d) => d.on) },
+                yAxis: { type: "value" },
+                series: fields.slice(0, 5).map(([key, label]) => ({
+                  name: label,
+                  type: "line",
+                  data: data.map((d) => d[key]),
+                  showSymbol: false,
+                })),
+                dataZoom: [{ type: "inside" }],
+              }}
+              style={{ height: 300 }}
+            />
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // Fallback: simple key-value table
+  return (
+    <Box>
+      {title && <Typography variant="h6">{title}</Typography>}
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <tbody>
+          {data &&
+            Object.entries(data).map(([k, v]) => (
+              <tr key={k}>
+                <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>{k}</td>
+                <td style={{ padding: 4, borderBottom: "1px solid #eee", textAlign: "right" }}>
+                  {v != null ? (typeof v === "number" ? v.toFixed(4) : String(v)) : "-"}
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </Box>
+  );
+};
 
 // DropdownMenu
 export const DropdownMenu = ({ label, children }) => {

--- a/frontend/src/lib/storybook/index.jsx
+++ b/frontend/src/lib/storybook/index.jsx
@@ -227,22 +227,43 @@ export const DictTable = ({ data, title, interests, chart }) => {
       <Box>
         {title && <Typography variant="h6">{title}</Typography>}
         <Box sx={{ overflowX: "auto" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.85rem" }}>
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              fontSize: "0.85rem",
+            }}
+          >
             <thead>
               <tr>
                 <th style={{ padding: 4, textAlign: "left" }}>Metric</th>
                 {data.map((d) => (
-                  <th key={d.on} style={{ padding: 4, textAlign: "right" }}>{d.on}</th>
+                  <th key={d.on} style={{ padding: 4, textAlign: "right" }}>
+                    {d.on}
+                  </th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {fields.map(([key, label]) => (
                 <tr key={key}>
-                  <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>{label}</td>
+                  <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>
+                    {label}
+                  </td>
                   {data.map((d) => (
-                    <td key={d.on} style={{ padding: 4, borderBottom: "1px solid #eee", textAlign: "right" }}>
-                      {d[key] != null ? (typeof d[key] === "number" ? d[key].toFixed(4) : String(d[key])) : "-"}
+                    <td
+                      key={d.on}
+                      style={{
+                        padding: 4,
+                        borderBottom: "1px solid #eee",
+                        textAlign: "right",
+                      }}
+                    >
+                      {d[key] != null
+                        ? typeof d[key] === "number"
+                          ? d[key].toFixed(4)
+                          : String(d[key])
+                        : "-"}
                     </td>
                   ))}
                 </tr>
@@ -283,9 +304,21 @@ export const DictTable = ({ data, title, interests, chart }) => {
           {data &&
             Object.entries(data).map(([k, v]) => (
               <tr key={k}>
-                <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>{k}</td>
-                <td style={{ padding: 4, borderBottom: "1px solid #eee", textAlign: "right" }}>
-                  {v != null ? (typeof v === "number" ? v.toFixed(4) : String(v)) : "-"}
+                <td style={{ padding: 4, borderBottom: "1px solid #eee" }}>
+                  {k}
+                </td>
+                <td
+                  style={{
+                    padding: 4,
+                    borderBottom: "1px solid #eee",
+                    textAlign: "right",
+                  }}
+                >
+                  {v != null
+                    ? typeof v === "number"
+                      ? v.toFixed(4)
+                      : String(v)
+                    : "-"}
                 </td>
               </tr>
             ))}

--- a/frontend/src/views/stock/BalanceView/index.jsx
+++ b/frontend/src/views/stock/BalanceView/index.jsx
@@ -56,7 +56,7 @@ const BalanceView = () => {
   };
 
   const render_data = (resp) => {
-    const { objects: data } = resp;
+    const data = Array.isArray(resp) ? resp : resp.objects || [];
 
     return (
       <>

--- a/frontend/src/views/stock/CashFlowView/index.jsx
+++ b/frontend/src/views/stock/CashFlowView/index.jsx
@@ -40,7 +40,7 @@ const CashFlowView = () => {
   };
 
   const render_data = (resp) => {
-    const data = resp.objects;
+    const data = Array.isArray(resp) ? resp : resp.objects || [];
 
     return (
       <>

--- a/frontend/src/views/stock/IncomeView/index.jsx
+++ b/frontend/src/views/stock/IncomeView/index.jsx
@@ -47,7 +47,7 @@ const IncomeView = () => {
   };
 
   const render_data = (resp) => {
-    const data = resp.objects;
+    const data = Array.isArray(resp) ? resp : resp.objects || [];
 
     return (
       <>

--- a/frontend/src/views/stock/ValuationRatiosView/index.jsx
+++ b/frontend/src/views/stock/ValuationRatiosView/index.jsx
@@ -17,7 +17,7 @@ const ValuationRatiosView = () => {
   };
 
   const render_data = (resp) => {
-    const data = resp.objects;
+    const data = Array.isArray(resp) ? resp : resp.objects || [];
 
     return (
       <FinancialCard title="Valuation Ratios" data={data} reported={reported} />


### PR DESCRIPTION
Step 1.9

- Rewrite Get to use useQuery (caching, deduplication)
- Rewrite PollResource to use refetchInterval
- Fix all remaining resp.objects patterns (8 files)
- Fix DictTable to render financial statement arrays correctly
- Same external interface — 25 callers unchanged