### PR TITLE
refactor(frontend): remove @mui/styles, fix layout and runtime crashes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
     "@fengxia41103/storybook": "1.2.0-dev.4",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.4",
-    "@mui/styles": "^5.11.2",
     "@mui/x-data-grid": "^5.17.19",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,11 +3,36 @@ import routes from "@/routes";
 import React from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 20, color: "red", fontFamily: "monospace" }}>
+          <h2>Runtime Error</h2>
+          <pre>{this.state.error.message}</pre>
+          <pre>{this.state.error.stack}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 const App = () => {
-  // goto where
   const router = createBrowserRouter(routes);
 
-  return <RouterProvider router={router} />;
+  return (
+    <ErrorBoundary>
+      <RouterProvider router={router} />
+    </ErrorBoundary>
+  );
 };
 
 export default App;

--- a/frontend/src/components/common/Get/index.jsx
+++ b/frontend/src/components/common/Get/index.jsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import api from "@/api/client";
 
 const Get = ({ uri, on_success, on_error, silent }) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, isFetching } = useQuery({
     queryKey: ["get", uri],
     queryFn: () =>
       api.get(encodeURI(uri)).then((r) => {
@@ -18,8 +18,9 @@ const Get = ({ uri, on_success, on_error, silent }) => {
     enabled: !!uri,
   });
 
-  if (isLoading) return silent ? null : <ScaleLoader loading />;
+  if (isLoading || (!data && isFetching)) return silent ? null : <ScaleLoader loading />;
   if (error) return on_error ? on_error(error) : null;
+  if (data === undefined) return silent ? null : <ScaleLoader loading />;
   return on_success ? on_success(data) : null;
 };
 

--- a/frontend/src/components/common/Get/index.jsx
+++ b/frontend/src/components/common/Get/index.jsx
@@ -18,7 +18,8 @@ const Get = ({ uri, on_success, on_error, silent }) => {
     enabled: !!uri,
   });
 
-  if (isLoading || (!data && isFetching)) return silent ? null : <ScaleLoader loading />;
+  if (isLoading || (!data && isFetching))
+    return silent ? null : <ScaleLoader loading />;
   if (error) return on_error ? on_error(error) : null;
   if (data === undefined) return silent ? null : <ScaleLoader loading />;
   return on_success ? on_success(data) : null;

--- a/frontend/src/components/dashboard/MoverCard/index.jsx
+++ b/frontend/src/components/dashboard/MoverCard/index.jsx
@@ -18,10 +18,8 @@ import { ColoredNumber } from "@fengxia41103/storybook";
 
 import TaskNotificationIcon from "@Components/task/TaskNotificationIcon";
 
-
 const MoverCard = (props) => {
   const { title, subtitle, stocks, value, roundTo } = props;
-  
 
   const entries = map(stocks, (s) => {
     return (

--- a/frontend/src/components/dashboard/MoverCard/index.jsx
+++ b/frontend/src/components/dashboard/MoverCard/index.jsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { map } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
@@ -14,25 +13,15 @@ import {
   ListItem,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
 
 import TaskNotificationIcon from "@Components/task/TaskNotificationIcon";
 
-const myStyles = makeStyles(() => ({
-  root: {
-    display: "flex",
-    flexDirection: "column",
-  },
-  card: {
-    height: "100%",
-  },
-}));
 
 const MoverCard = (props) => {
   const { title, subtitle, stocks, value, roundTo } = props;
-  const classes = myStyles();
+  
 
   const entries = map(stocks, (s) => {
     return (
@@ -69,7 +58,7 @@ const MoverCard = (props) => {
   );
 
   return (
-    <Card className={clsx(classes.root, classes.card)}>
+    <Card sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <CardHeader
         title={<Typography variant="h3">{title}</Typography>}
         subheader={subHeader}

--- a/frontend/src/components/news/ListNewsCard/index.jsx
+++ b/frontend/src/components/news/ListNewsCard/index.jsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { isEmpty, isNull, isUndefined, map } from "lodash";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
@@ -16,24 +15,14 @@ import {
   ListItem,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import ShowResource from "@Components/common/ShowResource";
 
-const myStyles = makeStyles(() => ({
-  root: {
-    display: "flex",
-    flexDirection: "column",
-  },
-  card: {
-    height: "100%",
-  },
-}));
 
 const ListNewsCard = (props) => {
   const { topic, limit, searching } = props;
   const [resource, setResource] = useState();
-  const classes = myStyles();
+  
   const limit_count = isUndefined(limit) ? 10 : limit;
 
   const get_uri = () => {
@@ -75,7 +64,7 @@ const ListNewsCard = (props) => {
       );
     });
     return (
-      <Card className={clsx(classes.root, classes.card)}>
+      <Card sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
         <CardHeader
           title={<Typography variant="h3">{topic.toUpperCase()}</Typography>}
         />

--- a/frontend/src/components/news/ListNewsCard/index.jsx
+++ b/frontend/src/components/news/ListNewsCard/index.jsx
@@ -18,11 +18,10 @@ import {
 
 import ShowResource from "@Components/common/ShowResource";
 
-
 const ListNewsCard = (props) => {
   const { topic, limit, searching } = props;
   const [resource, setResource] = useState();
-  
+
   const limit_count = isUndefined(limit) ? 10 : limit;
 
   const get_uri = () => {

--- a/frontend/src/components/stock/ListStockCard/index.jsx
+++ b/frontend/src/components/stock/ListStockCard/index.jsx
@@ -22,13 +22,11 @@ import { ColoredNumber, DropdownMenu } from "@fengxia41103/storybook";
 import RecentPriceSparkline from "@Components/stock/RecentPriceSparkline";
 import StockSymbol from "@Components/stock/StockSymbol";
 
-
 const ListStockCard = (props) => {
   // props
   const { stocks, index, group_by, actions } = props;
 
   // hooks
-  
 
   let title;
   switch (group_by) {

--- a/frontend/src/components/stock/ListStockCard/index.jsx
+++ b/frontend/src/components/stock/ListStockCard/index.jsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { isUndefined, map } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
@@ -17,34 +16,19 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import { ColoredNumber, DropdownMenu } from "@fengxia41103/storybook";
 
 import RecentPriceSparkline from "@Components/stock/RecentPriceSparkline";
 import StockSymbol from "@Components/stock/StockSymbol";
 
-const myStyles = makeStyles(() => ({
-  root: {
-    display: "flex",
-    flexDirection: "column",
-  },
-  avatar: {
-    backgroundColor: "#d52349",
-    height: 56,
-    width: 56,
-  },
-  card: {
-    height: "100%",
-  },
-}));
 
 const ListStockCard = (props) => {
   // props
   const { stocks, index, group_by, actions } = props;
 
   // hooks
-  const classes = myStyles();
+  
 
   let title;
   switch (group_by) {
@@ -116,12 +100,12 @@ const ListStockCard = (props) => {
   });
 
   return (
-    <Card className={clsx(classes.root, classes.card)}>
+    <Card sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <CardHeader
         title={<Typography variant="h3">{title}</Typography>}
         subheader={<Typography variant="body2">{group_by}</Typography>}
         avartar={
-          <Avatar className={classes.avatar}>
+          <Avatar sx={{ width: 60, height: 60 }}>
             <CalendarTodayIcon />
           </Avatar>
         }

--- a/frontend/src/components/user/AuthenticatedUser/index.jsx
+++ b/frontend/src/components/user/AuthenticatedUser/index.jsx
@@ -3,15 +3,13 @@ import React from "react";
 
 import { Avatar, Box, Typography } from "@mui/material";
 
-
 const AuthenticatedUser = (props) => {
-  
   const { user } = props;
 
   return (
     <Box alignItems="center" display="flex" flexDirection="column" p={2}>
       <Avatar sx={{ width: 60, height: 60 }} src={user.avatar} />
-      <Typography  color="textPrimary" variant="h5">
+      <Typography color="textPrimary" variant="h5">
         Welcome back
       </Typography>
       <Typography color="secondary" variant="body2">

--- a/frontend/src/components/user/AuthenticatedUser/index.jsx
+++ b/frontend/src/components/user/AuthenticatedUser/index.jsx
@@ -2,24 +2,16 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { Avatar, Box, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
-const useStyles = makeStyles(() => ({
-  avatar: {
-    cursor: "pointer",
-    width: 64,
-    height: 64,
-  },
-}));
 
 const AuthenticatedUser = (props) => {
-  const classes = useStyles();
+  
   const { user } = props;
 
   return (
     <Box alignItems="center" display="flex" flexDirection="column" p={2}>
-      <Avatar className={classes.avatar} src={user.avatar} />
-      <Typography className={classes.name} color="textPrimary" variant="h5">
+      <Avatar sx={{ width: 60, height: 60 }} src={user.avatar} />
+      <Typography  color="textPrimary" variant="h5">
         Welcome back
       </Typography>
       <Typography color="secondary" variant="body2">

--- a/frontend/src/layouts/MainLayout/index.jsx
+++ b/frontend/src/layouts/MainLayout/index.jsx
@@ -3,59 +3,28 @@ import React, { useState } from "react";
 import { Outlet } from "react-router-dom";
 
 import { Box } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import NavBar from "@Layouts/NavBar";
 import TopBar from "@Layouts/TopBar";
 
-const myStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.dark,
-    display: "flex",
-    height: "100%",
-    overflow: "hidden",
-    width: "100%",
-    paddingBottom: theme.spacing(3),
-    paddingTop: theme.spacing(3),
-  },
-  wrapper: {
-    display: "flex",
-    flex: "1 1 auto",
-    overflow: "hidden",
-    paddingTop: 64,
-    [theme.breakpoints.up("lg")]: {
-      paddingLeft: 256,
-    },
-  },
-  contentContainer: {
-    display: "flex",
-    flex: "1 1 auto",
-    overflow: "hidden",
-  },
-  content: {
-    flex: "1 1 auto",
-    height: "100%",
-    overflow: "auto",
-  },
-}));
 
 const MainLayout = (props) => {
   const { sideNavs } = props;
   const [isMobileNavOpen, setMobileNavOpen] = useState(false);
 
-  const classes = myStyles();
+  
 
   return (
-    <Box className={classes.root}>
+    <Box sx={{ display: "flex", height: "100%", overflow: "hidden", width: "100%" }}>
       <TopBar onMobileNavOpen={() => setMobileNavOpen(!isMobileNavOpen)} />
       <NavBar
         onMobileClose={() => setMobileNavOpen(false)}
         isMobileMode={isMobileNavOpen}
         items={sideNavs}
       />
-      <Box className={classes.wrapper}>
-        <Box className={classes.contentContainer}>
-          <Box className={classes.content}>
+      <Box sx={{ display: "flex", flex: "1 1 auto", overflow: "hidden", pt: "64px" }}>
+        <Box sx={{ display: "flex", flex: "1 1 auto", overflow: "hidden" }}>
+          <Box sx={{ flex: "1 1 auto", height: "100%", overflow: "auto" }}>
             <Outlet />
           </Box>
         </Box>

--- a/frontend/src/layouts/MainLayout/index.jsx
+++ b/frontend/src/layouts/MainLayout/index.jsx
@@ -2,32 +2,36 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { Outlet } from "react-router-dom";
 
-import { Box } from "@mui/material";
+import { Box, Toolbar } from "@mui/material";
 
 import NavBar from "@Layouts/NavBar";
 import TopBar from "@Layouts/TopBar";
 
+const DRAWER_WIDTH = 256;
 
 const MainLayout = (props) => {
   const { sideNavs } = props;
   const [isMobileNavOpen, setMobileNavOpen] = useState(false);
 
-  
-
   return (
-    <Box sx={{ display: "flex", height: "100%", overflow: "hidden", width: "100%" }}>
+    <Box sx={{ display: "flex" }}>
       <TopBar onMobileNavOpen={() => setMobileNavOpen(!isMobileNavOpen)} />
       <NavBar
         onMobileClose={() => setMobileNavOpen(false)}
         isMobileMode={isMobileNavOpen}
         items={sideNavs}
       />
-      <Box sx={{ display: "flex", flex: "1 1 auto", overflow: "hidden", pt: "64px" }}>
-        <Box sx={{ display: "flex", flex: "1 1 auto", overflow: "hidden" }}>
-          <Box sx={{ flex: "1 1 auto", height: "100%", overflow: "auto" }}>
-            <Outlet />
-          </Box>
-        </Box>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          overflow: "auto",
+          minHeight: "100vh",
+          ml: { lg: `${DRAWER_WIDTH}px` },
+        }}
+      >
+        <Toolbar />
+        <Outlet />
       </Box>
     </Box>
   );

--- a/frontend/src/layouts/NavBar/NavItem.jsx
+++ b/frontend/src/layouts/NavBar/NavItem.jsx
@@ -4,19 +4,22 @@ import PropTypes from "prop-types";
 import React from "react";
 import { NavLink } from "react-router-dom";
 
-
 const NavItem = ({ className, href, icon: Icon, title, ...rest }) => {
-  
-
   return (
-    <ListItem
-      sx={{ display: "flex", py: 0 }}
-      disableGutters
-      {...rest}
-    >
-      <Button sx={{ color: "text.secondary", fontWeight: "medium", justifyContent: "flex-start", textTransform: "none", width: "100%" }} component={NavLink} to={href}>
+    <ListItem sx={{ display: "flex", py: 0 }} disableGutters {...rest}>
+      <Button
+        sx={{
+          color: "text.secondary",
+          fontWeight: "medium",
+          justifyContent: "flex-start",
+          textTransform: "none",
+          width: "100%",
+        }}
+        component={NavLink}
+        to={href}
+      >
         {Icon && <Icon style={{ marginRight: 8 }} size="20" />}
-        <span >{title}</span>
+        <span>{title}</span>
       </Button>
     </ListItem>
   );

--- a/frontend/src/layouts/NavBar/NavItem.jsx
+++ b/frontend/src/layouts/NavBar/NavItem.jsx
@@ -1,55 +1,22 @@
 import { Button, ListItem } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
-import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 import { NavLink } from "react-router-dom";
 
-const myStyles = makeStyles((theme) => ({
-  item: {
-    display: "flex",
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-  button: {
-    color: theme.palette.text.secondary,
-    fontWeight: theme.typography.fontWeightMedium,
-    justifyContent: "flex-start",
-    letterSpacing: 0,
-    padding: "10px 8px",
-    textTransform: "none",
-    width: "100%",
-  },
-  icon: {
-    marginRight: theme.spacing(1),
-  },
-  title: {
-    marginRight: "auto",
-  },
-  active: {
-    color: theme.palette.primary.main,
-    "& $title": {
-      fontWeight: theme.typography.fontWeightMedium,
-    },
-    "& $icon": {
-      color: theme.palette.primary.main,
-    },
-  },
-}));
 
 const NavItem = ({ className, href, icon: Icon, title, ...rest }) => {
-  const classes = myStyles();
+  
 
   return (
     <ListItem
-      className={clsx(classes.item, className)}
+      sx={{ display: "flex", py: 0 }}
       disableGutters
       {...rest}
     >
-      <Button className={classes.button} component={NavLink} to={href}>
-        {Icon && <Icon className={classes.icon} size="20" />}
-        <span className={classes.title}>{title}</span>
+      <Button sx={{ color: "text.secondary", fontWeight: "medium", justifyContent: "flex-start", textTransform: "none", width: "100%" }} component={NavLink} to={href}>
+        {Icon && <Icon style={{ marginRight: 8 }} size="20" />}
+        <span >{title}</span>
       </Button>
     </ListItem>
   );

--- a/frontend/src/layouts/NavBar/index.jsx
+++ b/frontend/src/layouts/NavBar/index.jsx
@@ -11,7 +11,6 @@ import AuthenticatedUser from "@Components/user/AuthenticatedUser";
 
 import NavItem from "@Layouts/NavBarItem";
 
-
 const NavBar = (props) => {
   const { onMobileClose, isMobileMode, items } = props;
   const { user: username } = useContext(GlobalContext);
@@ -20,7 +19,6 @@ const NavBar = (props) => {
     name: username,
   };
 
-  
   const location = useLocation();
 
   const content = (
@@ -60,7 +58,9 @@ const NavBar = (props) => {
     <Box sx={{ display: { xs: "none", sm: "none", md: "none", lg: "block" } }}>
       <Drawer
         anchor="left"
-        PaperProps={{ sx: { width: 256, top: 64, height: "calc(100% - 64px)" } }}
+        PaperProps={{
+          sx: { width: 256, top: 64, height: "calc(100% - 64px)" },
+        }}
         open={!isMobileMode}
         variant="persistent"
       >

--- a/frontend/src/layouts/NavBar/index.jsx
+++ b/frontend/src/layouts/NavBar/index.jsx
@@ -4,7 +4,6 @@ import React, { useContext, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 import { Box, Divider, Drawer, Hidden, List } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import GlobalContext from "@/context";
 
@@ -12,16 +11,6 @@ import AuthenticatedUser from "@Components/user/AuthenticatedUser";
 
 import NavItem from "@Layouts/NavBarItem";
 
-const myStyles = makeStyles(() => ({
-  mobileDrawer: {
-    width: 256,
-  },
-  desktopDrawer: {
-    width: 256,
-    top: 64,
-    height: "calc(100% - 64px)",
-  },
-}));
 
 const NavBar = (props) => {
   const { onMobileClose, isMobileMode, items } = props;
@@ -31,7 +20,7 @@ const NavBar = (props) => {
     name: username,
   };
 
-  const classes = myStyles();
+  
   const location = useLocation();
 
   const content = (
@@ -58,7 +47,7 @@ const NavBar = (props) => {
     <Box sx={{ display: { xs: "block", sm: "block", md: "none", lg: "none" } }}>
       <Drawer
         anchor="left"
-        classes={{ paper: classes.mobileDrawer }}
+        PaperProps={{ sx: { width: 256 } }}
         onClose={onMobileClose}
         open={isMobileMode}
         variant="temporary"
@@ -71,7 +60,7 @@ const NavBar = (props) => {
     <Box sx={{ display: { xs: "none", sm: "none", md: "none", lg: "block" } }}>
       <Drawer
         anchor="left"
-        classes={{ paper: classes.desktopDrawer }}
+        PaperProps={{ sx: { width: 256, top: 64, height: "calc(100% - 64px)" } }}
         open={!isMobileMode}
         variant="persistent"
       >

--- a/frontend/src/layouts/NavBarItem/index.jsx
+++ b/frontend/src/layouts/NavBarItem/index.jsx
@@ -4,17 +4,24 @@ import { NavLink } from "react-router-dom";
 
 import { Button, Icon, ListItem } from "@mui/material";
 
-
 const NavItem = (props) => {
   const { href, icon, title } = props;
 
-  
-
   return (
     <ListItem sx={{ display: "flex", py: 0 }} disableGutters>
-      <Button sx={{ color: "text.secondary", fontWeight: "medium", justifyContent: "flex-start", textTransform: "none", width: "100%" }} component={NavLink} to={href}>
+      <Button
+        sx={{
+          color: "text.secondary",
+          fontWeight: "medium",
+          justifyContent: "flex-start",
+          textTransform: "none",
+          width: "100%",
+        }}
+        component={NavLink}
+        to={href}
+      >
         {icon && <Icon style={{ marginRight: 8 }} size="20" />}
-        <span >{title}</span>
+        <span>{title}</span>
       </Button>
     </ListItem>
   );

--- a/frontend/src/layouts/NavBarItem/index.jsx
+++ b/frontend/src/layouts/NavBarItem/index.jsx
@@ -3,50 +3,18 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 
 import { Button, Icon, ListItem } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
-const myStyles = makeStyles((theme) => ({
-  item: {
-    display: "flex",
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-  button: {
-    color: theme.palette.text.secondary,
-    fontWeight: theme.typography.fontWeightMedium,
-    justifyContent: "flex-start",
-    letterSpacing: 0,
-    padding: "10px 8px",
-    textTransform: "none",
-    width: "100%",
-  },
-  icon: {
-    marginRight: theme.spacing(1),
-  },
-  title: {
-    marginRight: "auto",
-  },
-  active: {
-    color: theme.palette.primary.main,
-    "& $title": {
-      fontWeight: theme.typography.fontWeightMedium,
-    },
-    "& $icon": {
-      color: theme.palette.primary.main,
-    },
-  },
-}));
 
 const NavItem = (props) => {
   const { href, icon, title } = props;
 
-  const classes = myStyles();
+  
 
   return (
-    <ListItem className={classes.item} disableGutters>
-      <Button className={classes.button} component={NavLink} to={href}>
-        {icon && <Icon className={classes.icon} size="20" />}
-        <span className={classes.title}>{title}</span>
+    <ListItem sx={{ display: "flex", py: 0 }} disableGutters>
+      <Button sx={{ color: "text.secondary", fontWeight: "medium", justifyContent: "flex-start", textTransform: "none", width: "100%" }} component={NavLink} to={href}>
+        {icon && <Icon style={{ marginRight: 8 }} size="20" />}
+        <span >{title}</span>
       </Button>
     </ListItem>
   );

--- a/frontend/src/layouts/TopBar/index.jsx
+++ b/frontend/src/layouts/TopBar/index.jsx
@@ -13,10 +13,7 @@ import LogoutIcon from "@Components/auth/LogoutIcon";
 import AddNewStockDialog from "@Components/stock/AddNewStockDialog";
 import TaskNotificationIcon from "@Components/task/TaskNotificationIcon";
 
-
 const TopBar = ({ className, onMobileNavOpen, ...rest }) => {
-  
-
   const actions = (
     <Stack alignItems="flex-start">
       <AddNewStockDialog />

--- a/frontend/src/layouts/TopBar/index.jsx
+++ b/frontend/src/layouts/TopBar/index.jsx
@@ -6,7 +6,6 @@ import { Link as RouterLink } from "react-router-dom";
 import MenuIcon from "@mui/icons-material/Menu";
 import { AppBar, Box, Hidden, IconButton, Toolbar } from "@mui/material";
 import { Button, Stack } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import { DropdownMenu, Logo } from "@fengxia41103/storybook";
 
@@ -14,16 +13,9 @@ import LogoutIcon from "@Components/auth/LogoutIcon";
 import AddNewStockDialog from "@Components/stock/AddNewStockDialog";
 import TaskNotificationIcon from "@Components/task/TaskNotificationIcon";
 
-const myStyles = makeStyles(() => ({
-  root: {},
-  avatar: {
-    width: 60,
-    height: 60,
-  },
-}));
 
 const TopBar = ({ className, onMobileNavOpen, ...rest }) => {
-  const classes = myStyles();
+  
 
   const actions = (
     <Stack alignItems="flex-start">
@@ -32,7 +24,7 @@ const TopBar = ({ className, onMobileNavOpen, ...rest }) => {
   );
 
   return (
-    <AppBar className={clsx(classes.root, className)} elevation={0} {...rest}>
+    <AppBar className={className} elevation={0} {...rest}>
       <Toolbar>
         <RouterLink to="/">
           <Logo />

--- a/frontend/src/lib/storybook/index.jsx
+++ b/frontend/src/lib/storybook/index.jsx
@@ -209,6 +209,8 @@ export const DictCard = ({ data, interests, title }) => {
             {data && data[k] != null
               ? typeof data[k] === "number"
                 ? data[k].toFixed(4)
+                : Array.isArray(data[k])
+                ? `[${data[k].length} items]`
                 : String(data[k])
               : "-"}
           </Typography>
@@ -329,19 +331,21 @@ export const DictTable = ({ data, title, interests, chart }) => {
 };
 
 // DropdownMenu
-export const DropdownMenu = ({ label, children }) => {
+export const DropdownMenu = ({ label, title, children, content }) => {
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const displayLabel = label || title || "Menu";
+  const displayContent = children || content;
   return (
     <>
       <Button onClick={(e) => setAnchorEl(e.currentTarget)}>
-        {label || "Menu"}
+        {displayLabel}
       </Button>
       <Menu
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(null)}
       >
-        {React.Children.map(children, (child, i) => (
+        {displayContent && React.Children.map(displayContent, (child, i) => (
           <MenuItem key={i} onClick={() => setAnchorEl(null)}>
             {child}
           </MenuItem>
@@ -353,10 +357,11 @@ export const DropdownMenu = ({ label, children }) => {
 
 // HighlightedText
 export const HighlightedText = ({ children, color, highlights, text, val }) => {
-  const bg = highlights || color || "#ffeb3b";
+  const bg = typeof highlights === "object" ? highlights?.background : highlights || color || "#ffeb3b";
+  const fg = typeof highlights === "object" ? highlights?.font : undefined;
   const display = text || children;
   return (
-    <span style={{ backgroundColor: bg, padding: "2px 6px", borderRadius: 4 }}>
+    <span style={{ backgroundColor: bg, color: fg, padding: "2px 6px", borderRadius: 4 }}>
       {display}
       {val != null
         ? ` (${typeof val === "number" ? val.toFixed(2) : val})`

--- a/frontend/src/lib/storybook/index.jsx
+++ b/frontend/src/lib/storybook/index.jsx
@@ -345,11 +345,12 @@ export const DropdownMenu = ({ label, title, children, content }) => {
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(null)}
       >
-        {displayContent && React.Children.map(displayContent, (child, i) => (
-          <MenuItem key={i} onClick={() => setAnchorEl(null)}>
-            {child}
-          </MenuItem>
-        ))}
+        {displayContent &&
+          React.Children.map(displayContent, (child, i) => (
+            <MenuItem key={i} onClick={() => setAnchorEl(null)}>
+              {child}
+            </MenuItem>
+          ))}
       </Menu>
     </>
   );
@@ -357,11 +358,21 @@ export const DropdownMenu = ({ label, title, children, content }) => {
 
 // HighlightedText
 export const HighlightedText = ({ children, color, highlights, text, val }) => {
-  const bg = typeof highlights === "object" ? highlights?.background : highlights || color || "#ffeb3b";
+  const bg =
+    typeof highlights === "object"
+      ? highlights?.background
+      : highlights || color || "#ffeb3b";
   const fg = typeof highlights === "object" ? highlights?.font : undefined;
   const display = text || children;
   return (
-    <span style={{ backgroundColor: bg, color: fg, padding: "2px 6px", borderRadius: 4 }}>
+    <span
+      style={{
+        backgroundColor: bg,
+        color: fg,
+        padding: "2px 6px",
+        borderRadius: 4,
+      }}
+    >
       {display}
       {val != null
         ? ` (${typeof val === "number" ? val.toFixed(2) : val})`

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { CssBaseline, ThemeProvider } from "@mui/material";
-import { ThemeProvider as StylesThemeProvider } from "@mui/styles";
 
 import App from "./App";
 import theme from "./theme";
@@ -21,10 +20,8 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <StylesThemeProvider theme={theme}>
-          <CssBaseline />
-          <App />
-        </StylesThemeProvider>
+        <CssBaseline />
+        <App />
       </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/frontend/src/views/stock/DailyReturnView/index.jsx
+++ b/frontend/src/views/stock/DailyReturnView/index.jsx
@@ -8,6 +8,7 @@ import { daily_return_stats, daily_returns } from "@Utils/stock/returns";
 
 const DailyReturnView = () => {
   const data = useContext(StockHistoricalContext);
+  if (!Array.isArray(data) || data.length < 2) return null;
   const returns = daily_returns(data);
   const stats = daily_return_stats(data);
   const p = { ...{ name: "Daytime Return", returns, stats } };

--- a/frontend/src/views/stock/OvernightReturnView/index.jsx
+++ b/frontend/src/views/stock/OvernightReturnView/index.jsx
@@ -11,6 +11,7 @@ import {
 
 const OvernightReturnView = () => {
   const data = useContext(StockHistoricalContext);
+  if (!Array.isArray(data) || data.length < 2) return null;
   const returns = overnight_returns(data);
   const stats = overnight_return_stats(data);
   const p = { ...{ name: "Overnight Return", returns, stats } };

--- a/frontend/src/views/stock/PriceView/index.jsx
+++ b/frontend/src/views/stock/PriceView/index.jsx
@@ -22,14 +22,11 @@ import PriceChart from "@Components/stock/PriceChart";
 
 import StockHistoricalContext from "@Views/stock/StockHistoricalView/context";
 
-
 const PriceView = () => {
   const data = useContext(StockHistoricalContext);
   if (!Array.isArray(data) || data.length === 0) return null;
   const [first_data] = data;
   const { symbol } = first_data;
-
-  
 
   const stocks = map(data, (d) => {
     return { ...d, week: dayjs(d.on).week() };

--- a/frontend/src/views/stock/PriceView/index.jsx
+++ b/frontend/src/views/stock/PriceView/index.jsx
@@ -25,6 +25,7 @@ import StockHistoricalContext from "@Views/stock/StockHistoricalView/context";
 
 const PriceView = () => {
   const data = useContext(StockHistoricalContext);
+  if (!Array.isArray(data) || data.length === 0) return null;
   const [first_data] = data;
   const { symbol } = first_data;
 

--- a/frontend/src/views/stock/PriceView/index.jsx
+++ b/frontend/src/views/stock/PriceView/index.jsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { groupBy, map, reverse } from "lodash";
 import dayjs from "dayjs";
 import weekOfYear from "dayjs/plugin/weekOfYear";
@@ -15,7 +14,6 @@ import {
   Grid,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
 
@@ -24,18 +22,13 @@ import PriceChart from "@Components/stock/PriceChart";
 
 import StockHistoricalContext from "@Views/stock/StockHistoricalView/context";
 
-const myStyles = makeStyles(() => ({
-  card: {
-    height: "100%",
-  },
-}));
 
 const PriceView = () => {
   const data = useContext(StockHistoricalContext);
   const [first_data] = data;
   const { symbol } = first_data;
 
-  const classes = myStyles();
+  
 
   const stocks = map(data, (d) => {
     return { ...d, week: dayjs(d.on).week() };
@@ -90,7 +83,7 @@ const PriceView = () => {
     <>
       <Grid container spacing={1}>
         <Grid item lg={8} md={8} sm={6} xs={12}>
-          <Card className={clsx(classes.card)}>
+          <Card sx={{ height: "100%" }}>
             <CardHeader
               title={
                 <Typography variant="h3">{symbol} Daily Prices</Typography>
@@ -102,7 +95,7 @@ const PriceView = () => {
           </Card>
         </Grid>
         <Grid item lg={4} md={4} sm={6} xs={12}>
-          <Card className={clsx(classes.card)}>
+          <Card sx={{ height: "100%" }}>
             <CardHeader
               title={<Typography variant="h3">Gain Probability</Typography>}
               subheader={

--- a/frontend/src/views/stock/TwentyFourHourReturnView/index.jsx
+++ b/frontend/src/views/stock/TwentyFourHourReturnView/index.jsx
@@ -11,6 +11,8 @@ import {
 
 const TwentyFourHourReturnView = () => {
   const data = useContext(StockHistoricalContext);
+  if (!Array.isArray(data) || data.length < 2) return null;
+
   const returns = twenty_four_hour_returns(data);
   const stats = twenty_four_hour_stats(data);
   const p = { ...{ name: "Return of 24-hour", returns, stats } };


### PR DESCRIPTION
Step 1.11 — Final Phase 1 step.

- Remove all makeStyles → sx prop (10 files)
- Remove @mui/styles from package.json
- Fix MainLayout: Toolbar spacer + drawer margin
- Fix Get: handle react-query v5 undefined data for disabled queries
- Fix HighlightedText: handle object highlights prop
- Fix DropdownMenu: accept title/content props
- Guard return views against empty context
- Add ErrorBoundary to App