### PR TITLE
feat: add drf-spectacular OpenAPI schema + TypeScript config

### DIFF
--- a/backend/fin/settings.py
+++ b/backend/fin/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "django_filters",
+    "drf_spectacular",
     "corsheaders",
     "django_celery_results",
     # Local
@@ -106,6 +107,13 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 200,
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+# OpenAPI schema
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Stock Analysis API",
+    "VERSION": "1.0.0",
 }
 
 # Celery

--- a/backend/fin/urls.py
+++ b/backend/fin/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("api/v1/", include("stock.api.urls")),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("admin/", admin.site.urls),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ mysqlclient>=2.2.0
 # REST API (replacing Tastypie)
 djangorestframework>=3.15.0
 django-filter>=24.0
+drf-spectacular>=0.28.0
 
 # Celery
 celery>=5.4.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,9 @@
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "prettier": "^3.4.2",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "typescript": "^5.7.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@Components/*": ["src/components/*"],
+      "@Views/*": ["src/views/*"],
+      "@Layouts/*": ["src/layouts/*"],
+      "@Utils/*": ["src/utils/*"],
+      "@fengxia41103/storybook": ["src/lib/storybook/index.jsx"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Step 2.3

- drf-spectacular: /api/schema/ + /api/docs/
- tsconfig.json: strict + allowJs for incremental adoption
- TypeScript devDependencies added