### PR TITLE
refactor(frontend): split storybook lib into charts/layout/display

### DIFF
--- a/frontend/src/lib/charts/index.js
+++ b/frontend/src/lib/charts/index.js
@@ -1,0 +1,8 @@
+// Chart components — re-exported from main storybook lib
+export {
+  HighchartGraph,
+  MultilineChart,
+  RankChart,
+  ABDonutChart,
+  TimeSeriesColumnChart,
+} from "@fengxia41103/storybook";

--- a/frontend/src/lib/display/index.js
+++ b/frontend/src/lib/display/index.js
@@ -1,0 +1,9 @@
+// Display components — re-exported from main storybook lib
+export {
+  ColoredNumber,
+  HighlightedText,
+  DictCard,
+  DictTable,
+  DropdownMenu,
+  SimpleSnackbar,
+} from "@fengxia41103/storybook";

--- a/frontend/src/lib/layout/index.js
+++ b/frontend/src/lib/layout/index.js
@@ -1,0 +1,8 @@
+// Layout components — re-exported from main storybook lib
+export {
+  Logo,
+  Page,
+  NotFoundView,
+  MenuBar,
+  AsDialog,
+} from "@fengxia41103/storybook";

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
       "@Layouts": resolve(__dirname, "src/layouts"),
       "@Utils": resolve(__dirname, "src/utils"),
       "@fengxia41103/storybook": resolve(__dirname, "src/lib/storybook/index.jsx"),
+      "@lib/charts": resolve(__dirname, "src/lib/charts/index.js"),
+      "@lib/layout": resolve(__dirname, "src/lib/layout/index.js"),
+      "@lib/display": resolve(__dirname, "src/lib/display/index.js"),
     },
   },
   server: {


### PR DESCRIPTION
Step 2.4

- Three new module entry points with vite aliases
- Backward compatible barrel export preserved