### PR TITLE
refactor(backend): split heavy stock endpoints into actions

### DIFF
--- a/backend/stock/api/serializers.py
+++ b/backend/stock/api/serializers.py
@@ -38,16 +38,13 @@ class StockListSerializer(serializers.ModelSerializer):
 class StockDetailSerializer(StockListSerializer):
     tax_rate = serializers.FloatField(read_only=True)
     latest_close_price = serializers.FloatField(read_only=True)
-    dupont_model = serializers.ListField(read_only=True)
-    nav_model = serializers.ListField(read_only=True)
     dupont_roe = serializers.FloatField(read_only=True)
     roe_dupont_reported_gap = serializers.FloatField(read_only=True)
-    cross_statements_model = serializers.ListField(read_only=True)
 
     class Meta(StockListSerializer.Meta):
         fields = StockListSerializer.Meta.fields + [
-            "tax_rate", "latest_close_price", "dupont_model", "nav_model",
-            "dupont_roe", "roe_dupont_reported_gap", "cross_statements_model",
+            "tax_rate", "latest_close_price",
+            "dupont_roe", "roe_dupont_reported_gap",
         ]
 
 

--- a/backend/stock/api/views.py
+++ b/backend/stock/api/views.py
@@ -145,6 +145,21 @@ class StockViewSet(viewsets.ModelViewSet):
         batch_update_helper(request.user, stock.symbol)
         return Response(StockListSerializer(stock).data)
 
+    @action(detail=True, methods=["get"])
+    def dupont(self, request, pk=None):
+        stock = self.get_object()
+        return Response(stock.dupont_model)
+
+    @action(detail=True, methods=["get"])
+    def nav(self, request, pk=None):
+        stock = self.get_object()
+        return Response(stock.nav_model)
+
+    @action(detail=True, methods=["get"], url_path="cross-statements")
+    def cross_statements(self, request, pk=None):
+        stock = self.get_object()
+        return Response(stock.cross_statements_model)
+
 
 class HistoricalViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = HistoricalSerializer


### PR DESCRIPTION
Step 2.8 — /dupont/, /nav/, /cross-statements/ as separate endpoints