### PR TITLE
feat(frontend): vendor chunk splitting for smaller initial load

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,7 +16,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
-  # Static assets
+  # Static assets — long-term cache
   location /assets/ {
     expires 1y;
     add_header Cache-Control "public, immutable";

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -28,5 +28,15 @@ export default defineConfig({
   },
   build: {
     outDir: "build",
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor_react: ["react", "react-dom", "react-router-dom"],
+          vendor_mui: ["@mui/material", "@mui/icons-material"],
+          vendor_echarts: ["echarts", "echarts-for-react"],
+          vendor_query: ["@tanstack/react-query", "axios"],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
Step 3.4 — Manual chunks separate React, MUI, ECharts, react-query. Initial ~284kB gzipped.