### PR TITLE
feat: refresh button, mobile layout, Django 5.2 + Python 3.12

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Core
-Django>=5.1,<5.2
+Django>=5.2,<5.3
 gunicorn>=22.0.0
 mysqlclient>=2.2.0
 

--- a/frontend/src/components/stock/ListStockCard/index.jsx
+++ b/frontend/src/components/stock/ListStockCard/index.jsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import ErrorIcon from "@mui/icons-material/Error";
+import RefreshIcon from "@mui/icons-material/Refresh";
 import {
   Avatar,
   Box,
@@ -12,6 +13,7 @@ import {
   CardHeader,
   Chip,
   Grid,
+  IconButton,
   List,
   ListItem,
   Tooltip,
@@ -19,9 +21,21 @@ import {
 } from "@mui/material";
 
 import { ColoredNumber } from "@fengxia41103/storybook";
+import { useUpdate } from "@/api";
 
 import RecentPriceSparkline from "@Components/stock/RecentPriceSparkline";
 import StockSymbol from "@Components/stock/StockSymbol";
+
+const RefreshButton = ({ id, symbol }) => {
+  const { mutate } = useUpdate(`/stocks/${id}/`, ["stocks"]);
+  return (
+    <Tooltip title={`Refresh ${symbol}`}>
+      <IconButton size="small" onClick={() => mutate({})}>
+        <RefreshIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+};
 
 const ListStockCard = (props) => {
   // props
@@ -95,6 +109,9 @@ const ListStockCard = (props) => {
                 <ColoredNumber val={s.pe} />
               </>
             ) : null}
+          </Grid>
+          <Grid item lg={1} sm={1} xs={1}>
+            <RefreshButton id={s.id} symbol={s.symbol} />
           </Grid>
         </Grid>
       </ListItem>

--- a/frontend/src/components/stock/PriceChart/index.jsx
+++ b/frontend/src/components/stock/PriceChart/index.jsx
@@ -36,14 +36,20 @@ const PriceChart = ({ data, earnings }) => {
     .map((e) => ({
       xAxis: e.report_date,
       lineStyle: {
-        color: e.surprise_pct > 0 ? "#2e7d32" : e.surprise_pct < 0 ? "#c62828" : "#757575",
+        color:
+          e.surprise_pct > 0
+            ? "#2e7d32"
+            : e.surprise_pct < 0
+            ? "#c62828"
+            : "#757575",
         type: "dashed",
         width: 2,
       },
       label: {
-        formatter: e.surprise_pct != null
-          ? `${e.surprise_pct > 0 ? "+" : ""}${e.surprise_pct.toFixed(1)}%`
-          : "📅",
+        formatter:
+          e.surprise_pct != null
+            ? `${e.surprise_pct > 0 ? "+" : ""}${e.surprise_pct.toFixed(1)}%`
+            : "📅",
         fontSize: 11,
         fontWeight: "bold",
         position: "start",
@@ -77,10 +83,13 @@ const PriceChart = ({ data, earnings }) => {
         lineStyle: { width: 3 },
         itemStyle: { color: "#1976d2" },
         showSymbol: false,
-        markLine: markLineData.length > 0 ? {
-          symbol: "none",
-          data: markLineData,
-        } : undefined,
+        markLine:
+          markLineData.length > 0
+            ? {
+                symbol: "none",
+                data: markLineData,
+              }
+            : undefined,
       },
       {
         name: "Open",

--- a/frontend/src/views/stock/StockDetailView/index.jsx
+++ b/frontend/src/views/stock/StockDetailView/index.jsx
@@ -128,28 +128,34 @@ const StockDetailView = () => {
       <Container maxWidth={false}>
         {/* Header */}
         <Stack
-          direction="row"
-          alignItems="center"
+          direction={{ xs: "column", sm: "row" }}
+          alignItems={{ xs: "flex-start", sm: "center" }}
           justifyContent="space-between"
+          spacing={1}
           mb={2}
         >
-          <Typography variant="h1">
-            {stock.name ? `${stock.name} (${symbol})` : symbol}
-          </Typography>
-          <Stack direction="row" spacing={1} alignItems="center">
-            {stock.latest_close_price && (
-              <Chip
-                label={`$${stock.latest_close_price.toFixed(2)}`}
-                size="small"
-              />
-            )}
-            {stock.last_price_date && (
-              <Typography variant="caption" color="text.secondary">
-                {stock.last_price_date}
-              </Typography>
-            )}
-            {isStale && <Chip label="Stale" size="small" color="warning" />}
-          </Stack>
+          <Box>
+            <Typography
+              variant="h4"
+              sx={{ fontSize: { xs: "1.3rem", md: "2rem" } }}
+            >
+              {stock.name ? `${stock.name} (${symbol})` : symbol}
+            </Typography>
+            <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>
+              {stock.latest_close_price && (
+                <Chip
+                  label={`$${stock.latest_close_price.toFixed(2)}`}
+                  size="small"
+                />
+              )}
+              {stock.last_price_date && (
+                <Typography variant="caption" color="text.secondary">
+                  {stock.last_price_date}
+                </Typography>
+              )}
+              {isStale && <Chip label="Stale" size="small" color="warning" />}
+            </Stack>
+          </Box>
           <IconButton onClick={(e) => setAnchorEl(e.currentTarget)}>
             <SettingsIcon />
           </IconButton>


### PR DESCRIPTION
Steps E, G, J:
- Per-stock refresh icon on list cards
- Responsive header (mobile-friendly)
- Django 5.2.15 + Python 3.12.13
- 34 tests pass